### PR TITLE
#58 [feat] 방 이름 수정하기 서버 연결

### DIFF
--- a/app/src/main/java/hous/release/android/presentation/enter_room/create_room/CreateRoomFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/enter_room/create_room/CreateRoomFragment.kt
@@ -23,6 +23,11 @@ class CreateRoomFragment :
         initIsSuccessCreateRoomCollector()
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        viewModel.resetRoomName()
+    }
+
     private fun initBackBtnClickListener() {
         binding.btnCreateRoomBack.setOnClickListener { findNavController().popBackStack() }
     }

--- a/app/src/main/java/hous/release/android/presentation/enter_room/create_room/CreateRoomFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/enter_room/create_room/CreateRoomFragment.kt
@@ -7,6 +7,7 @@ import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
 import hous.release.android.R
 import hous.release.android.databinding.FragmentCreateRoomBinding
+import hous.release.android.util.KeyBoardUtil
 import hous.release.android.util.binding.BindingFragment
 import hous.release.android.util.extension.repeatOnStarted
 import kotlinx.coroutines.flow.filter
@@ -19,6 +20,7 @@ class CreateRoomFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.viewModel = viewModel
+        initEditTextClearFocus()
         initBackBtnClickListener()
         initIsSuccessCreateRoomCollector()
     }
@@ -26,6 +28,12 @@ class CreateRoomFragment :
     override fun onDestroyView() {
         super.onDestroyView()
         viewModel.resetRoomName()
+    }
+
+    private fun initEditTextClearFocus() {
+        binding.layoutCreateRoom.setOnClickListener {
+            KeyBoardUtil.hide(requireActivity())
+        }
     }
 
     private fun initBackBtnClickListener() {

--- a/app/src/main/java/hous/release/android/presentation/enter_room/create_room/CreateRoomViewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/enter_room/create_room/CreateRoomViewModel.kt
@@ -3,8 +3,7 @@ package hous.release.android.presentation.enter_room.create_room
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import hous.release.domain.entity.request.DomainCreateRoomRequest
-import hous.release.domain.entity.response.DomainCreateRoomResponse
+import hous.release.domain.entity.response.NewRoom
 import hous.release.domain.repository.EnterRoomRepository
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,7 +22,7 @@ class CreateRoomViewModel @Inject constructor(
     private val _isSuccessCreateRoom = MutableSharedFlow<Boolean>()
     val isSuccessCreateRoom: SharedFlow<Boolean> = _isSuccessCreateRoom.asSharedFlow()
 
-    var newRoomInfo: DomainCreateRoomResponse = DomainCreateRoomResponse()
+    var newRoomInfo: NewRoom = NewRoom()
         private set
 
     fun resetRoomName() {
@@ -32,7 +31,7 @@ class CreateRoomViewModel @Inject constructor(
 
     fun postCreateRoom() {
         viewModelScope.launch {
-            enterRoomRepository.postCreateRoom(DomainCreateRoomRequest(roomName.value))
+            enterRoomRepository.postCreateRoom(roomName.value)
                 .onSuccess { response ->
                     newRoomInfo = response
                     _isSuccessCreateRoom.emit(true)

--- a/app/src/main/java/hous/release/android/presentation/enter_room/create_room/CreateRoomViewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/enter_room/create_room/CreateRoomViewModel.kt
@@ -26,6 +26,10 @@ class CreateRoomViewModel @Inject constructor(
     var newRoomInfo: DomainCreateRoomResponse = DomainCreateRoomResponse()
         private set
 
+    fun resetRoomName() {
+        roomName.value = ""
+    }
+
     fun postCreateRoom() {
         viewModelScope.launch {
             enterRoomRepository.postCreateRoom(DomainCreateRoomRequest(roomName.value))

--- a/app/src/main/java/hous/release/android/presentation/enter_room/enter_room_code/EnterRoomCodeFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/enter_room/enter_room_code/EnterRoomCodeFragment.kt
@@ -23,6 +23,11 @@ class EnterRoomCodeFragment :
         initIsSuccessGetRoomCollector()
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        viewModel.resetRoomCode()
+    }
+
     private fun initBackBtnClickListener() {
         binding.btnEnterRoomCodeBack.setOnClickListener { findNavController().popBackStack() }
     }

--- a/app/src/main/java/hous/release/android/presentation/enter_room/enter_room_code/EnterRoomCodeFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/enter_room/enter_room_code/EnterRoomCodeFragment.kt
@@ -7,6 +7,7 @@ import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
 import hous.release.android.R
 import hous.release.android.databinding.FragmentEnterRoomCodeBinding
+import hous.release.android.util.KeyBoardUtil
 import hous.release.android.util.binding.BindingFragment
 import hous.release.android.util.extension.repeatOnStarted
 import kotlinx.coroutines.flow.filter
@@ -19,6 +20,7 @@ class EnterRoomCodeFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.viewModel = viewModel
+        initEditTextClearFocus()
         initBackBtnClickListener()
         initIsSuccessGetRoomCollector()
     }
@@ -26,6 +28,12 @@ class EnterRoomCodeFragment :
     override fun onDestroyView() {
         super.onDestroyView()
         viewModel.resetRoomCode()
+    }
+
+    private fun initEditTextClearFocus() {
+        binding.layoutEnterRoomCode.setOnClickListener {
+            KeyBoardUtil.hide(requireActivity())
+        }
     }
 
     private fun initBackBtnClickListener() {

--- a/app/src/main/java/hous/release/android/presentation/enter_room/enter_room_code/EnterRoomCodeViewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/enter_room/enter_room_code/EnterRoomCodeViewModel.kt
@@ -3,7 +3,7 @@ package hous.release.android.presentation.enter_room.enter_room_code
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import hous.release.domain.entity.response.DomainGetRoomResponse
+import hous.release.domain.entity.response.Room
 import hous.release.domain.repository.EnterRoomRepository
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
@@ -19,8 +19,8 @@ class EnterRoomCodeViewModel @Inject constructor(
     private val _isSuccessGetRoom = MutableSharedFlow<Boolean>()
     val isSuccessGetRoom: SharedFlow<Boolean> = _isSuccessGetRoom.asSharedFlow()
 
-    private val _roomInfo = MutableStateFlow(DomainGetRoomResponse())
-    val roomInfo: StateFlow<DomainGetRoomResponse> = _roomInfo.asStateFlow()
+    private val _roomInfo = MutableStateFlow(Room())
+    val roomInfo: StateFlow<Room> = _roomInfo.asStateFlow()
 
     private val _isSuccessEnterRoom = MutableSharedFlow<Boolean>()
     val isSuccessEnterRoom: SharedFlow<Boolean> = _isSuccessEnterRoom.asSharedFlow()

--- a/app/src/main/java/hous/release/android/presentation/enter_room/enter_room_code/EnterRoomCodeViewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/enter_room/enter_room_code/EnterRoomCodeViewModel.kt
@@ -5,12 +5,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import hous.release.domain.entity.response.DomainGetRoomResponse
 import hous.release.domain.repository.EnterRoomRepository
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -29,6 +24,10 @@ class EnterRoomCodeViewModel @Inject constructor(
 
     private val _isSuccessEnterRoom = MutableSharedFlow<Boolean>()
     val isSuccessEnterRoom: SharedFlow<Boolean> = _isSuccessEnterRoom.asSharedFlow()
+
+    fun resetRoomCode() {
+        roomCode.value = ""
+    }
 
     fun getEnterRoomCode() {
         viewModelScope.launch {

--- a/app/src/main/java/hous/release/android/presentation/hous/EditHousNameActivity.kt
+++ b/app/src/main/java/hous/release/android/presentation/hous/EditHousNameActivity.kt
@@ -2,6 +2,7 @@ package hous.release.android.presentation.hous
 
 import android.os.Bundle
 import androidx.activity.viewModels
+import dagger.hilt.android.AndroidEntryPoint
 import hous.release.android.R
 import hous.release.android.databinding.ActivityEditHousNameBinding
 import hous.release.android.presentation.hous.HousFragment.Companion.ROOM_NAME
@@ -12,7 +13,9 @@ import hous.release.android.util.dialog.WarningDialogFragment.Companion.CONFIRM_
 import hous.release.android.util.dialog.WarningDialogFragment.Companion.DIALOG_WARNING
 import hous.release.android.util.dialog.WarningDialogFragment.Companion.WARNING_TYPE
 import hous.release.android.util.dialog.WarningType
+import hous.release.android.util.extension.repeatOnStarted
 
+@AndroidEntryPoint
 class EditHousNameActivity :
     BindingActivity<ActivityEditHousNameBinding>(R.layout.activity_edit_hous_name) {
     private val viewModel by viewModels<EditHousNameViewModel>()
@@ -22,6 +25,7 @@ class EditHousNameActivity :
         binding.vm = viewModel
         initBackBtnClickListener()
         initOriginalRoomName()
+        initIsSuccessEditHousNameCollector()
     }
 
     private fun initBackBtnClickListener() {
@@ -42,5 +46,13 @@ class EditHousNameActivity :
         viewModel.initOriginalRoomName(
             intent.getStringExtra(ROOM_NAME) ?: getString(R.string.edit_hous_name_hint_for_error)
         )
+    }
+
+    private fun initIsSuccessEditHousNameCollector() {
+        repeatOnStarted {
+            viewModel.isSuccessEditHousName.collect { isSuccess ->
+                if (isSuccess) finish()
+            }
+        }
     }
 }

--- a/app/src/main/java/hous/release/android/presentation/hous/EditHousNameActivity.kt
+++ b/app/src/main/java/hous/release/android/presentation/hous/EditHousNameActivity.kt
@@ -1,8 +1,10 @@
 package hous.release.android.presentation.hous
 
 import android.os.Bundle
+import androidx.activity.viewModels
 import hous.release.android.R
 import hous.release.android.databinding.ActivityEditHousNameBinding
+import hous.release.android.presentation.hous.HousFragment.Companion.ROOM_NAME
 import hous.release.android.util.binding.BindingActivity
 import hous.release.android.util.dialog.ConfirmClickListener
 import hous.release.android.util.dialog.WarningDialogFragment
@@ -13,9 +15,13 @@ import hous.release.android.util.dialog.WarningType
 
 class EditHousNameActivity :
     BindingActivity<ActivityEditHousNameBinding>(R.layout.activity_edit_hous_name) {
+    private val viewModel by viewModels<EditHousNameViewModel>()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        binding.vm = viewModel
         initBackBtnClickListener()
+        initOriginalRoomName()
     }
 
     private fun initBackBtnClickListener() {
@@ -30,5 +36,11 @@ class EditHousNameActivity :
                 }
             }.show(supportFragmentManager, DIALOG_WARNING)
         }
+    }
+
+    private fun initOriginalRoomName() {
+        viewModel.initOriginalRoomName(
+            intent.getStringExtra(ROOM_NAME) ?: getString(R.string.edit_hous_name_hint_for_error)
+        )
     }
 }

--- a/app/src/main/java/hous/release/android/presentation/hous/EditHousNameActivity.kt
+++ b/app/src/main/java/hous/release/android/presentation/hous/EditHousNameActivity.kt
@@ -6,6 +6,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import hous.release.android.R
 import hous.release.android.databinding.ActivityEditHousNameBinding
 import hous.release.android.presentation.hous.HousFragment.Companion.ROOM_NAME
+import hous.release.android.util.KeyBoardUtil
 import hous.release.android.util.binding.BindingActivity
 import hous.release.android.util.dialog.ConfirmClickListener
 import hous.release.android.util.dialog.WarningDialogFragment
@@ -23,9 +24,16 @@ class EditHousNameActivity :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding.vm = viewModel
+        initEditTextClearFocus()
         initBackBtnClickListener()
         initOriginalRoomName()
         initIsSuccessEditHousNameCollector()
+    }
+
+    private fun initEditTextClearFocus() {
+        binding.layoutEditHousName.setOnClickListener {
+            KeyBoardUtil.hide(this@EditHousNameActivity)
+        }
     }
 
     private fun initBackBtnClickListener() {

--- a/app/src/main/java/hous/release/android/presentation/hous/EditHousNameViewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/hous/EditHousNameViewModel.kt
@@ -1,16 +1,39 @@
 package hous.release.android.presentation.hous
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import hous.release.domain.repository.HousRepository
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
 
-
-class EditHousNameViewModel : ViewModel() {
+@HiltViewModel
+class EditHousNameViewModel @Inject constructor(
+    private val housRepository: HousRepository
+) : ViewModel() {
     var originalRoomName = ""
         private set
     val roomName = MutableStateFlow<String>("")
 
+    private val _isSuccessEditHousName = MutableStateFlow<Boolean>(false)
+    val isSuccessEditHousName: StateFlow<Boolean> = _isSuccessEditHousName.asStateFlow()
+
     fun initOriginalRoomName(name: String) {
         originalRoomName = name
         roomName.value = originalRoomName
+    }
+
+    fun putHousName() {
+        viewModelScope.launch {
+            housRepository.putHousName(roomName.value)
+                .onSuccess { isSuccess ->
+                    _isSuccessEditHousName.value = isSuccess
+                }
+                .onFailure { Timber.d(it.message.toString()) }
+        }
     }
 }

--- a/app/src/main/java/hous/release/android/presentation/hous/EditHousNameViewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/hous/EditHousNameViewModel.kt
@@ -1,0 +1,16 @@
+package hous.release.android.presentation.hous
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+
+
+class EditHousNameViewModel : ViewModel() {
+    var originalRoomName = ""
+        private set
+    val roomName = MutableStateFlow<String>("")
+
+    fun initOriginalRoomName(name: String) {
+        originalRoomName = name
+        roomName.value = originalRoomName
+    }
+}

--- a/app/src/main/java/hous/release/android/presentation/hous/HousFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/hous/HousFragment.kt
@@ -27,7 +27,11 @@ class HousFragment : BindingFragment<FragmentHousBinding>(R.layout.fragment_hous
 
     private fun initClickListener() {
         binding.btnHousEdit.setOnClickListener {
-            startActivity(Intent(requireContext(), EditHousNameActivity::class.java))
+            startActivity(
+                Intent(requireContext(), EditHousNameActivity::class.java).apply {
+                    putExtra(ROOM_NAME, viewModel.hous.value.roomName)
+                }
+            )
         }
     }
 
@@ -41,5 +45,9 @@ class HousFragment : BindingFragment<FragmentHousBinding>(R.layout.fragment_hous
                 homiesAdapter.submitList(homies)
             }
         }
+    }
+
+    companion object {
+        const val ROOM_NAME = "roomName"
     }
 }

--- a/app/src/main/java/hous/release/android/presentation/hous/HousFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/hous/HousFragment.kt
@@ -19,10 +19,14 @@ class HousFragment : BindingFragment<FragmentHousBinding>(R.layout.fragment_hous
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.vm = viewModel
-        viewModel.getHome()
         initClickListener()
         initHomiesAdapter()
         initHomiesObserver()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        viewModel.getHome()
     }
 
     private fun initClickListener() {

--- a/app/src/main/java/hous/release/android/util/KeyBoardUtil.kt
+++ b/app/src/main/java/hous/release/android/util/KeyBoardUtil.kt
@@ -1,0 +1,24 @@
+package hous.release.android.util
+
+import android.app.Activity
+import android.content.Context
+import android.view.inputmethod.InputMethodManager
+
+object KeyBoardUtil {
+    fun hide(activity: Activity) {
+        val inputMethodManager =
+            activity.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        activity.currentFocus?.let { view ->
+            inputMethodManager.hideSoftInputFromWindow(view.windowToken, 0)
+            view.clearFocus()
+        }
+    }
+
+    fun show(activity: Activity) {
+        val inputMethodManager =
+            activity.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        activity.currentFocus?.let { view ->
+            inputMethodManager.showSoftInput(view, 0)
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_edit_hous_name.xml
+++ b/app/src/main/res/layout/activity_edit_hous_name.xml
@@ -34,6 +34,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="12dp"
             android:layout_marginEnd="8dp"
+            android:onClick="@{()->vm.putHousName()}"
             android:padding="8dp"
             android:text="@string/edit_hous_name_done"
             android:textAppearance="@style/B1"

--- a/app/src/main/res/layout/activity_edit_hous_name.xml
+++ b/app/src/main/res/layout/activity_edit_hous_name.xml
@@ -5,6 +5,9 @@
 
     <data>
 
+        <variable
+            name="vm"
+            type="hous.release.android.presentation.hous.EditHousNameViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -74,11 +77,11 @@
             android:layout_marginTop="32dp"
             android:background="@null"
             android:gravity="center_horizontal"
-            android:hint="원래 방 이름"
+            android:hint="@{vm.originalRoomName}"
             android:importantForAutofill="no"
             android:inputType="text"
             android:maxLength="8"
-            android:text="원래 방 이름"
+            android:text="@={vm.roomName}"
             android:textAppearance="@style/B1"
             android:textColor="@color/hous_black"
             android:textColorHint="@color/hous_g_4"
@@ -100,7 +103,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
-            android:text="6/8"
+            android:text="@{@string/edit_hous_name_count(vm.roomName.length)}"
             android:textAppearance="@style/Description"
             android:textColor="@color/hous_g_5"
             app:layout_constraintEnd_toEndOf="@id/view_room_name"

--- a/app/src/main/res/layout/activity_edit_hous_name.xml
+++ b/app/src/main/res/layout/activity_edit_hous_name.xml
@@ -85,7 +85,7 @@
             android:text="@={vm.roomName}"
             android:textAppearance="@style/B1"
             android:textColor="@color/hous_black"
-            android:textColorHint="@color/hous_g_4"
+            android:textColorHint="@color/hous_g_5"
             app:layout_constraintEnd_toEndOf="@id/view_room_name"
             app:layout_constraintStart_toStartOf="@id/view_room_name"
             app:layout_constraintTop_toBottomOf="@id/tv_edit_hous_name_desc" />
@@ -96,7 +96,7 @@
             android:layout_height="2dp"
             android:layout_marginHorizontal="88dp"
             android:layout_marginTop="8dp"
-            android:background="@color/hous_blue"
+            android:background="@{vm.roomName.length() == 0 ? @color/hous_g_3 : @color/hous_blue }"
             app:layout_constraintTop_toBottomOf="@id/et_room_name" />
 
         <TextView

--- a/app/src/main/res/layout/activity_edit_hous_name.xml
+++ b/app/src/main/res/layout/activity_edit_hous_name.xml
@@ -11,6 +11,7 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_edit_hous_name"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context=".presentation.hous.EditHousNameActivity">

--- a/app/src/main/res/layout/dialog_warning.xml
+++ b/app/src/main/res/layout/dialog_warning.xml
@@ -16,7 +16,7 @@
         android:paddingStart="24dp"
         android:paddingTop="24dp"
         android:paddingEnd="30dp"
-        android:paddingBottom="20dp"
+        android:paddingBottom="12dp"
         tools:context=".util.dialog.WarningDialogFragment">
 
         <TextView
@@ -48,7 +48,8 @@
             android:id="@+id/tv_warning_confirm"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="24dp"
+            android:layout_marginTop="16dp"
+            android:paddingVertical="8dp"
             android:text="@{warning.confirm}"
             android:textAppearance="@style/B2"
             android:textColor="@color/hous_red"
@@ -61,6 +62,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginEnd="32dp"
+            android:paddingVertical="8dp"
             android:text="@{warning.cancel}"
             android:textAppearance="@style/B2"
             android:textColor="@color/hous_g_6"

--- a/app/src/main/res/layout/fragment_create_room.xml
+++ b/app/src/main/res/layout/fragment_create_room.xml
@@ -11,6 +11,7 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_create_room"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/hous_white"

--- a/app/src/main/res/layout/fragment_create_room.xml
+++ b/app/src/main/res/layout/fragment_create_room.xml
@@ -70,7 +70,7 @@
             android:text="@={viewModel.roomName}"
             android:textAppearance="@style/B2"
             android:textColor="@color/hous_black"
-            android:textColorHint="@color/hous_g_4"
+            android:textColorHint="@color/hous_g_5"
             app:layout_constraintBottom_toTopOf="@id/view_create_room"
             app:layout_constraintEnd_toStartOf="@id/tv_create_room_count"
             app:layout_constraintStart_toStartOf="@id/tv_create_room_title"
@@ -93,7 +93,7 @@
             android:layout_height="2dp"
             android:layout_marginHorizontal="16dp"
             android:layout_marginTop="6dp"
-            android:background="@color/hous_blue"
+            android:background="@{viewModel.roomName.length() == 0 ? @color/hous_g_3 : @color/hous_blue }"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toBottomOf="@id/et_create_room_name" />
 

--- a/app/src/main/res/layout/fragment_enter_room_code.xml
+++ b/app/src/main/res/layout/fragment_enter_room_code.xml
@@ -13,6 +13,7 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_enter_room_code"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/hous_white"

--- a/app/src/main/res/layout/fragment_enter_room_code.xml
+++ b/app/src/main/res/layout/fragment_enter_room_code.xml
@@ -71,7 +71,7 @@
             android:text="@={viewModel.roomCode}"
             android:textAppearance="@style/B2"
             android:textColor="@color/hous_black"
-            android:textColorHint="@color/hous_g_4"
+            android:textColorHint="@color/hous_g_5"
             app:layout_constraintBottom_toTopOf="@id/view_enter_room_code"
             app:layout_constraintEnd_toEndOf="@id/view_enter_room_code"
             app:layout_constraintStart_toStartOf="@id/tv_enter_room_code_title"
@@ -83,7 +83,7 @@
             android:layout_height="2dp"
             android:layout_marginHorizontal="16dp"
             android:layout_marginTop="6dp"
-            android:background="@color/hous_blue"
+            android:background="@{viewModel.roomCode.length() == 0 ? @color/hous_g_3 : @color/hous_blue }"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toBottomOf="@id/et_enter_room_code_name" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,12 +103,22 @@
     <!-- CreateRoom -->
     <string name="create_room_title">방 만들기</string>
     <string name="create_room_desc">멤버들이 확인할 수 있도록 방 이름을 설정해주세요.</string>
-    <string name="create_room_edit_text_hint">방 이름 설정</string>\
+    <string name="create_room_edit_text_hint">방 이름</string>\
     <string name="create_room_name_count">%d/8</string>
     <string name="create_room_dialog_img_desc">img of dialog enter room</string>
     <string name="create_room_dialog_copy_code">참여 코드 복사하기</string>
     <string name="crate_room_dialog_desc">방 생성이 완료 되었습니다.\n참여 코드를 복사해서\n룸메이트에게 공유해보세요!</string>
     <string name="create_room_dialog_kakao_share">카카오톡으로 공유하기</string>
+
+    <!-- EnterRoomCode -->
+    <string name="enter_room_code_title">방 초대코드 입력하기</string>
+    <string name="enter_room_code_desc">초대코드를 입력해야 방에 들어갈 수 있어요.</string>
+    <string name="enter_room_code_edit_text_hint">방 코드</string>
+    <string name="enter_room_code_warning">* 참여할 수 없는 코드예요.</string>
+    <string name="enter_room_code_btn">방 참여하기</string>
+    <string name="enter_room_code_dialog_owner_desc">님이</string>
+    <string name="enter_room_code_dialog_desc">초대한 방에 참여할까요?</string>
+    <string name="enter_room_code_dialog_enter">참여하기</string>
 
     <!-- Hous -->
     <string name="hous_title">%s님의,\n%s 하우스</string>
@@ -136,16 +146,6 @@
     <string name="edit_hous_name_title">우리 집 별명 바꾸기</string>
     <string name="edit_hous_name_hint_for_error">우리 집 별명</string>
     <string name="edit_hous_name_count">%d/8</string>
-
-    <!-- EnterRoomCode -->
-    <string name="enter_room_code_title">방 초대코드 입력하기</string>
-    <string name="enter_room_code_desc">초대코드를 입력해야 방에 들어갈 수 있어요.</string>
-    <string name="enter_room_code_edit_text_hint">방 코드 입력</string>
-    <string name="enter_room_code_warning">* 참여할 수 없는 코드예요.</string>
-    <string name="enter_room_code_btn">방 참여하기</string>
-    <string name="enter_room_code_dialog_owner_desc">님이</string>
-    <string name="enter_room_code_dialog_desc">초대한 방에 참여할까요?</string>
-    <string name="enter_room_code_dialog_enter">참여하기</string>
 
     <!-- To-Do -->
     <string name="to_do_small_letter">to-do</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,7 +113,7 @@
     <!-- EnterRoomCode -->
     <string name="enter_room_code_title">방 초대코드 입력하기</string>
     <string name="enter_room_code_desc">초대코드를 입력해야 방에 들어갈 수 있어요.</string>
-    <string name="enter_room_code_edit_text_hint">방 코드</string>
+    <string name="enter_room_code_edit_text_hint">방 초대코드</string>
     <string name="enter_room_code_warning">* 참여할 수 없는 코드예요.</string>
     <string name="enter_room_code_btn">방 참여하기</string>
     <string name="enter_room_code_dialog_owner_desc">님이</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -134,6 +134,8 @@
     <string name="edit_hous_name_back_img_desc">back button</string>
     <string name="edit_hous_name_done">저장</string>
     <string name="edit_hous_name_title">우리 집 별명 바꾸기</string>
+    <string name="edit_hous_name_hint_for_error">우리 집 별명</string>
+    <string name="edit_hous_name_count">%d/8</string>
 
     <!-- EnterRoomCode -->
     <string name="enter_room_code_title">방 초대코드 입력하기</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -19,7 +19,7 @@
         <item name="android:maxLines">1</item>
         <item name="android:textSize">14dp</item>
         <item name="android:textCursorDrawable">@drawable/shape_black_line</item>
-        <item name="colorControlNormal">@color/hous_g_5</item>
+        <item name="colorControlNormal">@color/hous_g_3</item>
         <item name="colorControlActivated">@color/hous_blue</item>
         <item name="android:paddingBottom">15dp</item>
         <item name="android:textAppearance">@style/B2</item>

--- a/data/src/main/java/hous/release/data/datasource/EnterRoomDataSource.kt
+++ b/data/src/main/java/hous/release/data/datasource/EnterRoomDataSource.kt
@@ -6,14 +6,13 @@ import hous.release.data.entity.response.CreateRoomResponse
 import hous.release.data.entity.response.EnterRoomResponse
 import hous.release.data.entity.response.GetRoomResponse
 import hous.release.data.service.EnterRoomService
-import hous.release.domain.entity.request.DomainCreateRoomRequest
 import javax.inject.Inject
 
 class EnterRoomDataSource @Inject constructor(
     private val enterRoomService: EnterRoomService
 ) {
-    suspend fun postCreateRoom(createRoomRequest: CreateRoomRequest): BaseResponse<CreateRoomResponse> =
-        enterRoomService.postCreateRoom(DomainCreateRoomRequest(name = createRoomRequest.name))
+    suspend fun postCreateRoom(roomName: String): BaseResponse<CreateRoomResponse> =
+        enterRoomService.postCreateRoom(CreateRoomRequest(name = roomName))
 
     suspend fun getEnterRoomCode(roomCode: String): BaseResponse<GetRoomResponse> =
         enterRoomService.getEnterRoomCode(roomCode)

--- a/data/src/main/java/hous/release/data/datasource/HousDataSource.kt
+++ b/data/src/main/java/hous/release/data/datasource/HousDataSource.kt
@@ -1,7 +1,9 @@
 package hous.release.data.datasource
 
+import hous.release.data.entity.request.EditHousNameRequest
 import hous.release.data.entity.response.BaseResponse
 import hous.release.data.entity.response.HousResponse
+import hous.release.data.entity.response.NoDataResponse
 import hous.release.data.service.HousService
 import javax.inject.Inject
 
@@ -10,4 +12,7 @@ class HousDataSource @Inject constructor(
 ) {
     suspend fun getHome(): BaseResponse<HousResponse> =
         housService.getHome()
+
+    suspend fun putHousName(name: String): NoDataResponse =
+        housService.putHousName(EditHousNameRequest(name))
 }

--- a/data/src/main/java/hous/release/data/entity/request/EditHousNameRequest.kt
+++ b/data/src/main/java/hous/release/data/entity/request/EditHousNameRequest.kt
@@ -1,0 +1,5 @@
+package hous.release.data.entity.request
+
+data class EditHousNameRequest(
+    val name: String
+)

--- a/data/src/main/java/hous/release/data/repository/EnterRoomRepositoryImpl.kt
+++ b/data/src/main/java/hous/release/data/repository/EnterRoomRepositoryImpl.kt
@@ -1,39 +1,36 @@
 package hous.release.data.repository
 
 import hous.release.data.datasource.EnterRoomDataSource
-import hous.release.data.entity.request.CreateRoomRequest
-import hous.release.domain.entity.request.DomainCreateRoomRequest
-import hous.release.domain.entity.response.DomainCreateRoomResponse
-import hous.release.domain.entity.response.DomainEnterRoomResponse
-import hous.release.domain.entity.response.DomainGetRoomResponse
+import hous.release.domain.entity.response.Room
+import hous.release.domain.entity.response.NewRoom
 import hous.release.domain.repository.EnterRoomRepository
 import javax.inject.Inject
 
 class EnterRoomRepositoryImpl @Inject constructor(
     private val enterRoomDataSource: EnterRoomDataSource
 ) : EnterRoomRepository {
-    override suspend fun postCreateRoom(createRoomRequest: DomainCreateRoomRequest): Result<DomainCreateRoomResponse> =
-        kotlin.runCatching { enterRoomDataSource.postCreateRoom(CreateRoomRequest(name = createRoomRequest.name)) }
+    override suspend fun postCreateRoom(roomName: String): Result<NewRoom> =
+        kotlin.runCatching { enterRoomDataSource.postCreateRoom(roomName) }
             .map { response ->
-                DomainCreateRoomResponse(
+                NewRoom(
                     roomCode = response.data.roomCode,
                     roomId = response.data.roomId
                 )
             }
 
-    override suspend fun getEnterRoomCode(roomCode: String): Result<DomainGetRoomResponse> =
+    override suspend fun getEnterRoomCode(roomCode: String): Result<Room> =
         kotlin.runCatching { enterRoomDataSource.getEnterRoomCode(roomCode) }
             .map { response ->
-                DomainGetRoomResponse(
+                Room(
                     nickname = response.data.nickname,
                     roomId = response.data.roomId
                 )
             }
 
-    override suspend fun postEnterRoomId(roomId: String): Result<DomainEnterRoomResponse> =
+    override suspend fun postEnterRoomId(roomId: String): Result<NewRoom> =
         kotlin.runCatching { enterRoomDataSource.postEnterRoomId(roomId) }
             .map { response ->
-                DomainEnterRoomResponse(
+                NewRoom(
                     roomCode = response.data.roomCode,
                     roomId = response.data.roomId
                 )

--- a/data/src/main/java/hous/release/data/repository/HousRepositoryImpl.kt
+++ b/data/src/main/java/hous/release/data/repository/HousRepositoryImpl.kt
@@ -11,4 +11,8 @@ class HousRepositoryImpl @Inject constructor(
     override suspend fun getHome(): Result<Hous> =
         kotlin.runCatching { housDataSource.getHome() }
             .map { response -> response.data.toHous() }
+
+    override suspend fun putHousName(name: String): Result<Boolean> =
+        kotlin.runCatching { housDataSource.putHousName(name) }
+            .map { response -> response.success }
 }

--- a/data/src/main/java/hous/release/data/service/EnterRoomService.kt
+++ b/data/src/main/java/hous/release/data/service/EnterRoomService.kt
@@ -1,20 +1,16 @@
 package hous.release.data.service
 
+import hous.release.data.entity.request.CreateRoomRequest
 import hous.release.data.entity.response.BaseResponse
 import hous.release.data.entity.response.CreateRoomResponse
 import hous.release.data.entity.response.EnterRoomResponse
 import hous.release.data.entity.response.GetRoomResponse
-import hous.release.domain.entity.request.DomainCreateRoomRequest
-import retrofit2.http.Body
-import retrofit2.http.GET
-import retrofit2.http.POST
-import retrofit2.http.Path
-import retrofit2.http.Query
+import retrofit2.http.*
 
 interface EnterRoomService {
     @POST("/v1/room")
     suspend fun postCreateRoom(
-        @Body body: DomainCreateRoomRequest
+        @Body body: CreateRoomRequest
     ): BaseResponse<CreateRoomResponse>
 
     @GET("/v1/room/info")

--- a/data/src/main/java/hous/release/data/service/HousService.kt
+++ b/data/src/main/java/hous/release/data/service/HousService.kt
@@ -1,10 +1,19 @@
 package hous.release.data.service
 
+import hous.release.data.entity.request.EditHousNameRequest
 import hous.release.data.entity.response.BaseResponse
 import hous.release.data.entity.response.HousResponse
+import hous.release.data.entity.response.NoDataResponse
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.PUT
 
 interface HousService {
     @GET("/v1/home")
     suspend fun getHome(): BaseResponse<HousResponse>
+
+    @PUT("/v1/room/name")
+    suspend fun putHousName(
+        @Body body: EditHousNameRequest
+    ): NoDataResponse
 }

--- a/domain/src/main/java/hous/release/domain/entity/request/DomainCreateRoomRequest.kt
+++ b/domain/src/main/java/hous/release/domain/entity/request/DomainCreateRoomRequest.kt
@@ -1,5 +1,0 @@
-package hous.release.domain.entity.request
-
-data class DomainCreateRoomRequest(
-    val name: String
-)

--- a/domain/src/main/java/hous/release/domain/entity/response/DomainEnterRoomResponse.kt
+++ b/domain/src/main/java/hous/release/domain/entity/response/DomainEnterRoomResponse.kt
@@ -1,6 +1,0 @@
-package hous.release.domain.entity.response
-
-data class DomainEnterRoomResponse(
-    val roomCode: String,
-    val roomId: Int
-)

--- a/domain/src/main/java/hous/release/domain/entity/response/NewRoom.kt
+++ b/domain/src/main/java/hous/release/domain/entity/response/NewRoom.kt
@@ -1,6 +1,6 @@
 package hous.release.domain.entity.response
 
-data class DomainCreateRoomResponse(
+data class NewRoom(
     val roomCode: String = "",
     val roomId: Int = -1
 )

--- a/domain/src/main/java/hous/release/domain/entity/response/Room.kt
+++ b/domain/src/main/java/hous/release/domain/entity/response/Room.kt
@@ -1,6 +1,6 @@
 package hous.release.domain.entity.response
 
-data class DomainGetRoomResponse(
+data class Room(
     val nickname: String? = "",
     val roomId: Int? = -1
 )

--- a/domain/src/main/java/hous/release/domain/repository/EnterRoomRepository.kt
+++ b/domain/src/main/java/hous/release/domain/repository/EnterRoomRepository.kt
@@ -1,14 +1,12 @@
 package hous.release.domain.repository
 
-import hous.release.domain.entity.request.DomainCreateRoomRequest
-import hous.release.domain.entity.response.DomainCreateRoomResponse
-import hous.release.domain.entity.response.DomainEnterRoomResponse
-import hous.release.domain.entity.response.DomainGetRoomResponse
+import hous.release.domain.entity.response.Room
+import hous.release.domain.entity.response.NewRoom
 
 interface EnterRoomRepository {
-    suspend fun postCreateRoom(createRoomRequest: DomainCreateRoomRequest): Result<DomainCreateRoomResponse>
+    suspend fun postCreateRoom(roomName: String): Result<NewRoom>
 
-    suspend fun getEnterRoomCode(roomCode: String): Result<DomainGetRoomResponse>
+    suspend fun getEnterRoomCode(roomCode: String): Result<Room>
 
-    suspend fun postEnterRoomId(roomId: String): Result<DomainEnterRoomResponse>
+    suspend fun postEnterRoomId(roomId: String): Result<NewRoom>
 }

--- a/domain/src/main/java/hous/release/domain/repository/HousRepository.kt
+++ b/domain/src/main/java/hous/release/domain/repository/HousRepository.kt
@@ -4,4 +4,6 @@ import hous.release.domain.entity.response.Hous
 
 interface HousRepository {
     suspend fun getHome(): Result<Hous>
+
+    suspend fun putHousName(name: String): Result<Boolean>
 }


### PR DESCRIPTION
## 관련 이슈
- closed #58

## 작업한 내용
- 방 이름 수정하기 서버 연결
- 방 생성하기/참여하기 서버 통신 부분 domain, data 분리 로직 수정
-  KeyBoardUtil(EditText focus 관리) 구현 및 적용
-  방 생성하기, 초대코드 입력 뷰 이탈 시 editText의 Text 리셋하기
  - activityViewModels 사용으로 화면 이탈해도 해당 데이터 유지되는 현상 확인 후 수정했습니다.

## KeyBoardUtil
hide의 경우 키보드를 숨기고 싶을 때 : 예를 들어 editText에서 작성 중이다가 여백 클릭으로도 키보드를 끄고 싶을 때 등등
show의 경우 키보드를 보이고 싶을 때 : 예를 들어 기디 측에서 어떤 뷰에 들어가자마자 키보드를 올려달라거나 등등
<img width="771" alt="image" src="https://user-images.githubusercontent.com/68374234/197402329-a1fa88e6-505e-460d-8015-a8d787a32125.png">

### in Activity 
(layoutXXXXX은 해당 뷰ConstraintLayout을 가리킵니다.)
<img width="534" alt="image" src="https://user-images.githubusercontent.com/68374234/197402347-30c48d0a-32b1-4c00-a421-c64254c5e0a6.png">

### in Fragment
(layoutXXXXX은 해당 뷰ConstraintLayout을 가리킵니다.)
<img width="542" alt="image" src="https://user-images.githubusercontent.com/68374234/197402355-cc5c4a6c-ad6d-42c4-9113-6b006d3b5256.png">


## PR 포인트
- KeyBoardUtil 사용법 보시면 될 것 같구,, 포인트,, 음,, domain에 request 없애버린거 칭찬해주세요? ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ
