### PR TITLE
#71 [ui] todo empty 뷰 구현

### DIFF
--- a/app/src/main/java/hous/release/android/presentation/todo/detail/daily/DailyAdapter.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/detail/daily/DailyAdapter.kt
@@ -1,6 +1,7 @@
 package hous.release.android.presentation.todo.detail.daily
 
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -20,7 +21,14 @@ class DailyAdapter(
     ) :
         RecyclerView.ViewHolder(binding.root) {
         fun bind(todo: TodoMain) {
-            binding.tvToDoDailyTotal.text = "${todo.ourTodosCnt}"
+            with(binding) {
+                tvToDoDailyTotal.text = "${todo.ourTodosCnt}"
+                if (todo.myTodos.isEmpty()) tvDailyMyEmpty.visibility = View.VISIBLE
+                else tvDailyMyEmpty.visibility = View.GONE
+
+                if (todo.ourTodos.isEmpty()) tvDailyOurEmpty.visibility = View.VISIBLE
+                else tvDailyOurEmpty.visibility = View.GONE
+            }
         }
 
         fun fetchDailyMyToDos(myToDos: List<Todo>) {

--- a/app/src/main/java/hous/release/android/presentation/todo/detail/member/MemberAdapter.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/detail/member/MemberAdapter.kt
@@ -1,6 +1,7 @@
 package hous.release.android.presentation.todo.detail.member
 
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -19,7 +20,11 @@ class MemberAdapter(
         private val showTodoBottomSheet: (Int) -> Unit
     ) : RecyclerView.ViewHolder(binding.root) {
         fun onBind(memberTodo: MemberTodoContent) {
-            binding.tvToDoDailyTotal.text = memberTodo.totalTodoCnt.toString()
+            with(binding) {
+                tvToDoDailyTotal.text = memberTodo.totalTodoCnt.toString()
+                if (memberTodo.totalTodoCnt == 0) tvMemberTodoEmpty.visibility = View.VISIBLE
+                else tvMemberTodoEmpty.visibility = View.GONE
+            }
         }
 
         fun fetchMemberTodos(memberTodos: List<MemberTodo>) {

--- a/app/src/main/java/hous/release/android/presentation/todo/detail/member/MemberTodoAdapter.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/detail/member/MemberTodoAdapter.kt
@@ -38,18 +38,16 @@ class MemberTodoAdapter(
             }
         }
 
-        fun initTodoDetailOnClick(memberTodo: MemberTodo) {
-            if (memberTodo.todoCnt != 0) {
-                with(binding) {
-                    clMemberDayOfWeekDetail.setOnClickListener { view ->
-                        view.isSelected = !view.isSelected
-                        if (view.isSelected) {
-                            rvMemberToDo.visibility = View.GONE
-                            ivToDoDetail.setImageResource(R.drawable.ic_to_do_up)
-                        } else {
-                            rvMemberToDo.visibility = View.VISIBLE
-                            ivToDoDetail.setImageResource(R.drawable.ic_to_do_down)
-                        }
+        fun initTodoDetailOnClick() {
+            with(binding) {
+                clMemberDayOfWeekDetail.setOnClickListener { view ->
+                    view.isSelected = !view.isSelected
+                    if (view.isSelected) {
+                        rvMemberToDo.visibility = View.GONE
+                        ivToDoDetail.setImageResource(R.drawable.ic_to_do_up)
+                    } else {
+                        rvMemberToDo.visibility = View.VISIBLE
+                        ivToDoDetail.setImageResource(R.drawable.ic_to_do_down)
                     }
                 }
             }
@@ -67,7 +65,7 @@ class MemberTodoAdapter(
         holder.initAdapter()
         holder.onBind(current)
         holder.fetchTodos(current.dayOfWeekTodos)
-        holder.initTodoDetailOnClick(current)
+        holder.initTodoDetailOnClick()
     }
 
     companion object {

--- a/app/src/main/java/hous/release/android/presentation/todo/main/TodoFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/main/TodoFragment.kt
@@ -56,6 +56,8 @@ class TodoFragment : BindingFragment<FragmentToDoBinding>(R.layout.fragment_to_d
                         RoundedLinearIndicatorWithHomie(currentProgress = toDoUiState.progress)
                     }
                 }
+                if (toDoUiState.myTodosCount != 0) binding.tvToDoMyEmpty.visibility = View.GONE
+                if (toDoUiState.ourTodosCount != 0) binding.tvToDoOurEmpty.visibility = View.GONE
                 myToDoAdapter?.submitList(toDoUiState.myTodos)
                 ourToDoAdapter?.submitList(toDoUiState.ourTodos)
             }

--- a/app/src/main/java/hous/release/android/presentation/todo/main/TodoFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/main/TodoFragment.kt
@@ -56,8 +56,12 @@ class TodoFragment : BindingFragment<FragmentToDoBinding>(R.layout.fragment_to_d
                         RoundedLinearIndicatorWithHomie(currentProgress = toDoUiState.progress)
                     }
                 }
-                if (toDoUiState.myTodosCount != 0) binding.tvToDoMyEmpty.visibility = View.GONE
-                if (toDoUiState.ourTodosCount != 0) binding.tvToDoOurEmpty.visibility = View.GONE
+                if (toDoUiState.myTodosCount == 0) binding.tvToDoMyEmpty.visibility = View.VISIBLE
+                else binding.tvToDoMyEmpty.visibility = View.GONE
+
+                if (toDoUiState.ourTodosCount == 0) binding.tvToDoOurEmpty.visibility = View.VISIBLE
+                else binding.tvToDoOurEmpty.visibility = View.GONE
+                
                 myToDoAdapter?.submitList(toDoUiState.myTodos)
                 ourToDoAdapter?.submitList(toDoUiState.ourTodos)
             }

--- a/app/src/main/java/hous/release/android/presentation/todo/main/TodoFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/main/TodoFragment.kt
@@ -14,6 +14,7 @@ import hous.release.android.R
 import hous.release.android.databinding.FragmentToDoBinding
 import hous.release.android.presentation.todo.detail.TodoDetailActivity
 import hous.release.android.util.binding.BindingFragment
+import hous.release.android.util.component.TodoMainEmpty
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
@@ -49,7 +50,11 @@ class TodoFragment : BindingFragment<FragmentToDoBinding>(R.layout.fragment_to_d
             .flowWithLifecycle(lifecycle)
             .onEach { toDoUiState ->
                 binding.cvToDoProgress.setContent {
-                    RoundedLinearIndicatorWithHomie(currentProgress = toDoUiState.progress)
+                    if (toDoUiState.myTodosCount == 0 && toDoUiState.ourTodosCount == 0) {
+                        TodoMainEmpty()
+                    } else {
+                        RoundedLinearIndicatorWithHomie(currentProgress = toDoUiState.progress)
+                    }
                 }
                 myToDoAdapter?.submitList(toDoUiState.myTodos)
                 ourToDoAdapter?.submitList(toDoUiState.ourTodos)

--- a/app/src/main/java/hous/release/android/util/component/TodoMainEmpty.kt
+++ b/app/src/main/java/hous/release/android/util/component/TodoMainEmpty.kt
@@ -1,0 +1,62 @@
+package hous.release.android.util.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import hous.release.android.R
+
+@Composable
+fun TodoMainEmpty() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(colorResource(id = R.color.hous_blue_l2_80))
+    ) {
+        Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp)) {
+            Spacer(modifier = Modifier.height(28.dp))
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(R.string.todo_main_empty_progress),
+                textAlign = TextAlign.Center,
+                color = colorResource(id = R.color.hous_g_5),
+                style = TextStyle(
+                    fontFamily = FontFamily(Font(R.font.spoqa_han_sans_neo_medium)),
+                    fontWeight = FontWeight.Normal,
+                    fontSize = 12.sp,
+                    letterSpacing = (-0.02).sp,
+                    lineHeight = 3.6.sp
+                )
+            )
+            Spacer(modifier = Modifier.height(13.dp))
+            RoundedLinearIndicator(
+                modifier = Modifier.fillMaxWidth().padding(4.dp),
+                progress = 0.0f,
+                trackColor = colorResource(id = R.color.hous_blue_l2),
+                backgroundColor = colorResource(id = R.color.hous_blue_l2)
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun TodoMainEmptyPreview() {
+    TodoMainEmpty()
+}

--- a/app/src/main/res/layout/fragment_member.xml
+++ b/app/src/main/res/layout/fragment_member.xml
@@ -10,6 +10,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@color/hous_g_1"
         tools:context=".presentation.todo.detail.member.MemberFragment">
 
         <ImageView

--- a/app/src/main/res/layout/fragment_to_do.xml
+++ b/app/src/main/res/layout/fragment_to_do.xml
@@ -148,19 +148,36 @@
                     app:layout_constraintTop_toTopOf="@+id/iv_to_do_my_dot"
                     tools:text="2" />
 
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/rv_to_do_my_rules"
+                <FrameLayout
+                    android:id="@+id/fl_to_do_my"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="16dp"
                     android:layout_marginTop="16dp"
-                    android:nestedScrollingEnabled="false"
-                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/tv_to_do_my_title"
-                    tools:itemCount="4"
-                    tools:listitem="@layout/item_to_do_my_rule" />
+                    app:layout_constraintTop_toBottomOf="@+id/tv_to_do_my_title">
+
+                    <androidx.recyclerview.widget.RecyclerView
+                        android:id="@+id/rv_to_do_my_rules"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:nestedScrollingEnabled="false"
+                        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                        tools:itemCount="0"
+                        tools:listitem="@layout/item_to_do_my_rule" />
+
+                    <TextView
+                        android:id="@+id/tv_to_do_my_empty"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:paddingTop="28dp"
+                        android:paddingBottom="28dp"
+                        android:text="@string/to_do_my_empty"
+                        android:textAlignment="center"
+                        android:textAppearance="@style/B2"
+                        android:textColor="@color/hous_g_5" />
+                </FrameLayout>
 
                 <com.google.android.material.divider.MaterialDivider
                     android:id="@+id/divider_to_do_my"
@@ -168,9 +185,9 @@
                     android:layout_height="1dp"
                     android:layout_marginTop="8dp"
                     app:dividerColor="@color/hous_g_2"
-                    app:layout_constraintEnd_toEndOf="@+id/rv_to_do_my_rules"
-                    app:layout_constraintStart_toStartOf="@+id/rv_to_do_my_rules"
-                    app:layout_constraintTop_toBottomOf="@+id/rv_to_do_my_rules" />
+                    app:layout_constraintEnd_toEndOf="@+id/fl_to_do_my"
+                    app:layout_constraintStart_toStartOf="@+id/fl_to_do_my"
+                    app:layout_constraintTop_toBottomOf="@+id/fl_to_do_my" />
 
                 <TextView
                     android:id="@+id/tv_to_do_our_title"
@@ -225,19 +242,36 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toTopOf="@+id/tv_to_do_our_title" />
 
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/rv_to_do_our_rules"
+                <FrameLayout
+                    android:id="@+id/fl_to_do_our"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="16dp"
                     android:layout_marginTop="16dp"
-                    android:nestedScrollingEnabled="false"
-                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/tv_to_do_our_title"
-                    tools:itemCount="4"
-                    tools:listitem="@layout/item_to_do_our_rule" />
+                    app:layout_constraintTop_toBottomOf="@+id/tv_to_do_our_title">
+
+                    <androidx.recyclerview.widget.RecyclerView
+                        android:id="@+id/rv_to_do_our_rules"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:nestedScrollingEnabled="false"
+                        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                        tools:itemCount="4"
+                        tools:listitem="@layout/item_to_do_our_rule" />
+
+                    <TextView
+                        android:id="@+id/tv_to_do_our_empty"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:paddingTop="28dp"
+                        android:paddingBottom="28dp"
+                        android:text="@string/to_do_our_empty"
+                        android:textAlignment="center"
+                        android:textAppearance="@style/B2"
+                        android:textColor="@color/hous_g_5" />
+                </FrameLayout>
 
                 <com.google.android.material.divider.MaterialDivider
                     android:id="@+id/divider_to_do_our"
@@ -245,12 +279,11 @@
                     android:layout_height="1dp"
                     android:layout_marginTop="12dp"
                     app:dividerColor="@color/hous_g_2"
-                    app:layout_constraintEnd_toEndOf="@+id/rv_to_do_our_rules"
-                    app:layout_constraintStart_toStartOf="@+id/rv_to_do_our_rules"
-                    app:layout_constraintTop_toBottomOf="@+id/rv_to_do_our_rules" />
+                    app:layout_constraintEnd_toEndOf="@+id/fl_to_do_our"
+                    app:layout_constraintStart_toStartOf="@+id/fl_to_do_our"
+                    app:layout_constraintTop_toBottomOf="@+id/fl_to_do_our" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.core.widget.NestedScrollView>
-
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_to_do_daily.xml
+++ b/app/src/main/res/layout/item_to_do_daily.xml
@@ -64,19 +64,37 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/ll_to_do_daily_total" />
 
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/rv_to_do_daily_my_rules"
+            <FrameLayout
+                android:id="@+id/fl_todo_daily_my"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="16dp"
                 android:layout_marginTop="4dp"
-                android:nestedScrollingEnabled="false"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/tv_to_do_daily_my_title"
-                tools:itemCount="4"
-                tools:listitem="@layout/item_to_do_daily_my_rule" />
+                app:layout_constraintTop_toBottomOf="@+id/tv_to_do_daily_my_title">
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/rv_to_do_daily_my_rules"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:nestedScrollingEnabled="false"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                    tools:itemCount="0"
+                    tools:listitem="@layout/item_to_do_daily_my_rule" />
+
+                <TextView
+                    android:id="@+id/tv_daily_my_empty"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingTop="24dp"
+                    android:paddingBottom="28dp"
+                    android:text="@string/to_do_my_empty"
+                    android:textAlignment="center"
+                    android:textAppearance="@style/B2"
+                    android:textColor="@color/hous_g_5" />
+            </FrameLayout>
 
             <com.google.android.material.divider.MaterialDivider
                 android:id="@+id/divider_to_do_daily_my"
@@ -84,9 +102,9 @@
                 android:layout_height="1dp"
                 android:layout_marginTop="24dp"
                 app:dividerColor="@color/hous_g_2"
-                app:layout_constraintEnd_toEndOf="@+id/rv_to_do_daily_my_rules"
-                app:layout_constraintStart_toStartOf="@+id/rv_to_do_daily_my_rules"
-                app:layout_constraintTop_toBottomOf="@+id/rv_to_do_daily_my_rules" />
+                app:layout_constraintEnd_toEndOf="@+id/fl_todo_daily_my"
+                app:layout_constraintStart_toStartOf="@+id/fl_todo_daily_my"
+                app:layout_constraintTop_toBottomOf="@+id/fl_todo_daily_my" />
 
             <TextView
                 android:id="@+id/tv_to_do_daily_our_title"
@@ -103,19 +121,36 @@
                 app:layout_constraintStart_toStartOf="@+id/divider_to_do_daily_my"
                 app:layout_constraintTop_toBottomOf="@+id/divider_to_do_daily_my" />
 
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/rv_to_do_daily_our_rules"
+            <FrameLayout
+                android:id="@+id/fl_todo_daily_our"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="16dp"
                 android:layout_marginTop="16dp"
-                android:nestedScrollingEnabled="false"
-                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/tv_to_do_daily_our_title"
-                tools:itemCount="4"
-                tools:listitem="@layout/item_to_do_daily_our_rule" />
+                app:layout_constraintTop_toBottomOf="@+id/tv_to_do_daily_our_title">
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/rv_to_do_daily_our_rules"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:nestedScrollingEnabled="false"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                    tools:itemCount="0"
+                    tools:listitem="@layout/item_to_do_daily_our_rule" />
+
+                <TextView
+                    android:id="@+id/tv_daily_our_empty"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingTop="24dp"
+                    android:paddingBottom="28dp"
+                    android:text="@string/to_do_our_empty"
+                    android:textAlignment="center"
+                    android:textAppearance="@style/B2"
+                    android:textColor="@color/hous_g_5" />
+            </FrameLayout>
 
             <com.google.android.material.divider.MaterialDivider
                 android:id="@+id/divider_to_do_daily_our"
@@ -123,9 +158,9 @@
                 android:layout_height="1dp"
                 android:layout_marginTop="12dp"
                 app:dividerColor="@color/hous_g_2"
-                app:layout_constraintEnd_toEndOf="@+id/rv_to_do_daily_our_rules"
-                app:layout_constraintStart_toStartOf="@+id/rv_to_do_daily_our_rules"
-                app:layout_constraintTop_toBottomOf="@+id/rv_to_do_daily_our_rules" />
+                app:layout_constraintEnd_toEndOf="@+id/fl_todo_daily_our"
+                app:layout_constraintStart_toStartOf="@+id/fl_todo_daily_our"
+                app:layout_constraintTop_toBottomOf="@+id/fl_todo_daily_our" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/item_to_do_member.xml
+++ b/app/src/main/res/layout/item_to_do_member.xml
@@ -41,16 +41,33 @@
                 android:textColor="@color/hous_g_5" />
         </LinearLayout>
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/rv_to_do_member"
+        <FrameLayout
+            android:id="@+id/fl_member_todos"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
-            android:nestedScrollingEnabled="false"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/ll_to_do_daily_total" />
+            app:layout_constraintTop_toBottomOf="@+id/ll_to_do_daily_total">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_to_do_member"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:nestedScrollingEnabled="false"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+
+            <TextView
+                android:id="@+id/tv_member_todo_empty"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="36dp"
+                android:paddingBottom="28dp"
+                android:text="@string/to_do_my_empty"
+                android:textAlignment="center"
+                android:textAppearance="@style/B2"
+                android:textColor="@color/hous_g_5" />
+        </FrameLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -13,6 +13,7 @@
     <color name="hous_blue">#5E9EFF</color>
     <color name="hous_blue_l1">#BCD7FF</color>
     <color name="hous_blue_l2">#F5F9FF</color>
+    <color name="hous_blue_l2_80">#80f5f9ff</color>
     <color name="hous_purple">#d99cff</color>
     <color name="kakao_brown">#4e2a00</color>
     <color name="hous_green">#93e491</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -205,4 +205,5 @@
     <string name="to_do_limit_title">to-do 개수 초과</string>
     <string name="to_do_limit_content">우리 집 to-do가 너무 많아요!\n필요하지 않은 to-do를 삭제하고\n다시 시도해주세요~</string>
     <string name="todo_limit_confirm">알겠어요!</string>
+    <string name="todo_main_empty_progress">아직 완료할 to-do가 없어요!</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -206,4 +206,6 @@
     <string name="to_do_limit_content">우리 집 to-do가 너무 많아요!\n필요하지 않은 to-do를 삭제하고\n다시 시도해주세요~</string>
     <string name="todo_limit_confirm">알겠어요!</string>
     <string name="todo_main_empty_progress">아직 완료할 to-do가 없어요!</string>
+    <string name="to_do_my_empty">아직 담당하는 to-do가 없어요!</string>
+    <string name="to_do_our_empty">우리 집 to-do를 추가해 봐요!</string>
 </resources>

--- a/data/src/main/java/hous/release/data/entity/response/MemberTodoResponse.kt
+++ b/data/src/main/java/hous/release/data/entity/response/MemberTodoResponse.kt
@@ -25,7 +25,9 @@ data class MemberTodoResponse(
 
     fun toMemberTodoContent() = MemberTodoContent(
         color = HomyType.valueOf(color),
-        dayOfWeekTodos = dayOfWeekTodos.map { memberTodo -> memberTodo.toMemberTodo() },
+        dayOfWeekTodos = dayOfWeekTodos
+            .map { memberTodo -> memberTodo.toMemberTodo() }
+            .filter { memberTodo -> memberTodo.todoCnt != 0 },
         totalTodoCnt = totalTodoCnt,
         userName = userName
     )


### PR DESCRIPTION
## 관련 이슈
- closed #71 

https://user-images.githubusercontent.com/82709044/197506748-dcac11d6-6cb0-40f3-b5bd-2166e132807d.mp4

## 작업한 내용
- todo main, 멤버 별 보기, 요일 별 보기 empty 뷰 구현 및 적용

## PR 포인트
- **empty 뷰를 위한 FrameLayout 사용**
    - view group 하나 더 쓴게 맘에 안 들지만 제약 땜시...

- **mapper 과정 filter 처리**
    - 멤버별 보기 뷰가 todo가 없는 요일은 안 보이도록 수정이 되어서 필터링 추가
    - 코틀린 너무 좋다

- 까먹고 안한 멤버별 보기 탭 background 설정
