### PR TITLE
#99 [ui, fix] 프로필 뷰 내에 오각형 구현

### DIFF
--- a/app/src/main/java/hous/release/android/presentation/badge/BadgeActivity.kt
+++ b/app/src/main/java/hous/release/android/presentation/badge/BadgeActivity.kt
@@ -5,9 +5,9 @@ import androidx.activity.ComponentActivity
 import androidx.activity.addCallback
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.compose.material.MaterialTheme
 import dagger.hilt.android.AndroidEntryPoint
 import hous.release.android.presentation.badge.BadgeViewModel.Companion.NON_SELECTED
+import hous.release.android.util.style.HousTheme
 
 @AndroidEntryPoint
 class BadgeActivity : ComponentActivity() {
@@ -15,7 +15,7 @@ class BadgeActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            MaterialTheme {
+            HousTheme {
                 HousBadgeScreen(badgeViewModel = badgeViewModel) {
                     finish()
                 }

--- a/app/src/main/java/hous/release/android/presentation/badge/HousBadgeScreen.kt
+++ b/app/src/main/java/hous/release/android/presentation/badge/HousBadgeScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -179,41 +180,61 @@ private fun <T> LazyListScope.gridItems(
 @Composable
 private fun RepresentBadge(representBadge: Badge?) {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Surface(
-            modifier = Modifier.size(100.dp),
-            elevation = 10.dp,
-            shape = CircleShape
-        ) {
-            if (representBadge == null) {
-                Text(
-                    modifier = Modifier
-                        .wrapContentSize()
-                        .padding(horizontal = 16.dp, vertical = 23.dp),
-                    text = stringResource(id = R.string.represent_badge),
-                    textAlign = TextAlign.Center,
-                    color = colorResource(id = R.color.hous_g_4),
-                    style = TextStyle(
-                        fontFamily = FontFamily(
-                            Font(
-                                R.font.spoqa_han_sans_neo_medium,
-                                FontWeight.W500,
-                                FontStyle.Normal
+        if (representBadge == null) {
+            Box(
+                modifier = Modifier
+                    .background(
+                        brush = Brush.radialGradient(
+                            colors = listOf(
+                                colorResource(id = R.color.hous_red),
+                                colorResource(id = R.color.hous_g_7)
                             )
-                        ),
-                        fontWeight = FontWeight.Normal,
-                        fontSize = dpToSp(12.dp),
-                        letterSpacing = (-0.02).sp,
-                        lineHeight = 16.sp
+                        )
                     )
-                )
-            } else {
+                    .size(118.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Surface(
+                    modifier = Modifier
+                        .size(100.dp),
+                    elevation = 10.dp,
+                    shape = CircleShape
+                ) {
+                    Text(
+                        modifier = Modifier
+                            .wrapContentSize()
+                            .padding(horizontal = 16.dp, vertical = 23.dp),
+                        text = stringResource(id = R.string.represent_badge),
+                        textAlign = TextAlign.Center,
+                        color = colorResource(id = R.color.hous_g_4),
+                        style = TextStyle(
+                            fontFamily = FontFamily(
+                                Font(
+                                    R.font.spoqa_han_sans_neo_medium,
+                                    FontWeight.W500,
+                                    FontStyle.Normal
+                                )
+                            ),
+                            fontWeight = FontWeight.Normal,
+                            fontSize = dpToSp(12.dp),
+                            letterSpacing = (-0.02).sp,
+                            lineHeight = 16.sp
+                        )
+                    )
+                }
+            }
+        } else {
+            Surface(
+                modifier = Modifier
+                    .size(100.dp),
+                elevation = 10.dp,
+                shape = CircleShape
+            ) {
                 AsyncImage(
                     model = representBadge.imageUrl,
                     contentDescription = null
                 )
             }
-        }
-        if (representBadge != null) {
             Spacer(modifier = Modifier.height(12.dp))
             Text(
                 text = representBadge.name,

--- a/app/src/main/java/hous/release/android/presentation/badge/HousBadgeScreen.kt
+++ b/app/src/main/java/hous/release/android/presentation/badge/HousBadgeScreen.kt
@@ -33,19 +33,13 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.Font
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontStyle
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import hous.release.android.R
 import hous.release.android.util.component.HousBadge
-import hous.release.android.util.component.dpToSp
+import hous.release.android.util.style.HousTheme
 import hous.release.domain.entity.Badge
 
 @Composable
@@ -109,13 +103,7 @@ private fun BadgeToolBar(
         Text(
             text = stringResource(R.string.badge_title),
             color = colorResource(id = R.color.hous_white),
-            style = TextStyle(
-                fontFamily = FontFamily(Font(R.font.spoqa_han_sans_neo_medium)),
-                fontWeight = FontWeight.Normal,
-                fontSize = dpToSp(16.dp),
-                letterSpacing = (-0.02).sp,
-                lineHeight = 8.sp
-            )
+            style = HousTheme.typography.b1
         )
     }
 }
@@ -207,19 +195,7 @@ private fun RepresentBadge(representBadge: Badge?) {
                         text = stringResource(id = R.string.represent_badge),
                         textAlign = TextAlign.Center,
                         color = colorResource(id = R.color.hous_g_4),
-                        style = TextStyle(
-                            fontFamily = FontFamily(
-                                Font(
-                                    R.font.spoqa_han_sans_neo_medium,
-                                    FontWeight.W500,
-                                    FontStyle.Normal
-                                )
-                            ),
-                            fontWeight = FontWeight.Normal,
-                            fontSize = dpToSp(12.dp),
-                            letterSpacing = (-0.02).sp,
-                            lineHeight = 16.sp
-                        )
+                        style = HousTheme.typography.description
                     )
                 }
             }
@@ -239,19 +215,7 @@ private fun RepresentBadge(representBadge: Badge?) {
             Text(
                 text = representBadge.name,
                 color = colorResource(id = R.color.hous_white),
-                style = TextStyle(
-                    fontFamily = FontFamily(
-                        Font(
-                            R.font.spoqa_han_sans_neo,
-                            FontWeight.W700,
-                            FontStyle.Normal
-                        )
-                    ),
-                    fontWeight = FontWeight.Bold,
-                    fontSize = dpToSp(18.dp),
-                    letterSpacing = (-0.02).sp,
-                    lineHeight = 5.4.sp
-                )
+                style = HousTheme.typography.h4
             )
         }
     }

--- a/app/src/main/java/hous/release/android/presentation/personality/result/PersonalityResultActivity.kt
+++ b/app/src/main/java/hous/release/android/presentation/personality/result/PersonalityResultActivity.kt
@@ -6,6 +6,8 @@ import dagger.hilt.android.AndroidEntryPoint
 import hous.release.android.R
 import hous.release.android.databinding.ActivityPersonalityResultBinding
 import hous.release.android.util.binding.BindingActivity
+import hous.release.android.util.component.PersonalityResultImage
+import hous.release.android.util.style.HousTheme
 
 @AndroidEntryPoint
 class PersonalityResultActivity :
@@ -17,6 +19,7 @@ class PersonalityResultActivity :
         binding.vm = personalityResultViewModel
         initTitlePosition()
         initBackOnClickListener()
+        initPersonalityImage()
     }
 
     private fun initTitlePosition() {
@@ -24,6 +27,19 @@ class PersonalityResultActivity :
             when (intent.getStringExtra(LOCATION)) {
                 RESULT -> personalityResultViewModel.initFromTestResult(true)
                 else -> personalityResultViewModel.initFromTestResult(false)
+            }
+        }
+    }
+
+    private fun initPersonalityImage() {
+        personalityResultViewModel.resultData.observe(this) { personalityResult ->
+            binding.cvPersonalityResultImage.setContent {
+                HousTheme {
+                    PersonalityResultImage(
+                        homyType = personalityResult.color,
+                        imageUrl = personalityResult.imageUrl
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/hous/release/android/presentation/profile/ProfileFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/profile/ProfileFragment.kt
@@ -9,6 +9,8 @@ import dagger.hilt.android.AndroidEntryPoint
 import hous.release.android.R
 import hous.release.android.databinding.FragmentProfileBinding
 import hous.release.android.presentation.badge.BadgeActivity
+import hous.release.android.presentation.personality.result.PersonalityResultActivity
+import hous.release.android.presentation.personality.result.PersonalityResultActivity.Companion.LOCATION
 import hous.release.android.presentation.profile.adapter.ProfilePersonalityAdapter
 import hous.release.android.util.binding.BindingFragment
 import hous.release.android.util.component.HousPersonalityPentagon
@@ -37,9 +39,11 @@ class ProfileFragment : BindingFragment<FragmentProfileBinding>(R.layout.fragmen
     }
 
     private fun initPersonalityOnClickListener() {
-//        val intent = Intent(requireActivity(), PersonalityResultActivity::class.java)
-//        intent.putExtra(LOCATION, PROFILE)
-//        startActivity(intent)
+        binding.llProfilePersonalityDetail.setOnClickListener {
+            val intent = Intent(requireActivity(), PersonalityResultActivity::class.java)
+            intent.putExtra(LOCATION, PROFILE)
+            startActivity(intent)
+        }
     }
 
     private fun initAlarmOnClickListener() {

--- a/app/src/main/java/hous/release/android/presentation/profile/ProfileFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/profile/ProfileFragment.kt
@@ -10,6 +10,7 @@ import hous.release.android.R
 import hous.release.android.databinding.FragmentProfileBinding
 import hous.release.android.presentation.personality.result.PersonalityResultActivity.Companion.LOCATION
 import hous.release.android.presentation.badge.BadgeActivity
+import hous.release.android.presentation.personality.result.PersonalityResultActivity
 import hous.release.android.presentation.profile.adapter.ProfilePersonalityAdapter
 import hous.release.android.util.binding.BindingFragment
 import hous.release.domain.entity.HomyType
@@ -36,9 +37,9 @@ class ProfileFragment : BindingFragment<FragmentProfileBinding>(R.layout.fragmen
     }
 
     private fun initPersonalityOnClickListener() {
-        val intent = Intent(requireActivity(), PersonalityResult::class.java)
-        intent.putExtra(LOCATION, PROFILE)
-        startActivity(intent)
+//        val intent = Intent(requireActivity(), PersonalityResultActivity::class.java)
+//        intent.putExtra(LOCATION, PROFILE)
+//        startActivity(intent)
     }
 
     private fun initAlarmOnClickListener() {

--- a/app/src/main/java/hous/release/android/presentation/profile/ProfileFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/profile/ProfileFragment.kt
@@ -96,9 +96,14 @@ class ProfileFragment : BindingFragment<FragmentProfileBinding>(R.layout.fragmen
     }
 
     private fun observePersonalityPentagon() {
-        binding.cvProfilePersonalityPentagon.setContent {
-            HousTheme {
-                HousPersonalityPentagon(radiusList = listOf(5, 5, 5, 5, 5), homyType = HomyType.RED)
+        profileViewModel.profileData.observe(viewLifecycleOwner) { profile ->
+            binding.cvProfilePersonalityPentagon.setContent {
+                HousTheme {
+                    HousPersonalityPentagon(
+                        testScore = profile.testScore,
+                        homyType = profile.personalityColor
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/hous/release/android/presentation/profile/ProfileFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/profile/ProfileFragment.kt
@@ -8,15 +8,12 @@ import androidx.fragment.app.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import hous.release.android.R
 import hous.release.android.databinding.FragmentProfileBinding
-import hous.release.android.presentation.personality.result.PersonalityResultActivity.Companion.LOCATION
 import hous.release.android.presentation.badge.BadgeActivity
-import hous.release.android.presentation.personality.result.PersonalityResultActivity
 import hous.release.android.presentation.profile.adapter.ProfilePersonalityAdapter
 import hous.release.android.util.binding.BindingFragment
 import hous.release.domain.entity.HomyType
 import hous.release.domain.entity.PersonalityInfo
 import hous.release.domain.entity.ProfileSet
-import hous.release.domain.entity.response.PersonalityResult
 
 @AndroidEntryPoint
 class ProfileFragment : BindingFragment<FragmentProfileBinding>(R.layout.fragment_profile) {

--- a/app/src/main/java/hous/release/android/presentation/profile/ProfileFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/profile/ProfileFragment.kt
@@ -11,6 +11,8 @@ import hous.release.android.databinding.FragmentProfileBinding
 import hous.release.android.presentation.badge.BadgeActivity
 import hous.release.android.presentation.profile.adapter.ProfilePersonalityAdapter
 import hous.release.android.util.binding.BindingFragment
+import hous.release.android.util.component.HousPersonalityPentagon
+import hous.release.android.util.style.HousTheme
 import hous.release.domain.entity.HomyType
 import hous.release.domain.entity.PersonalityInfo
 import hous.release.domain.entity.ProfileSet
@@ -31,6 +33,7 @@ class ProfileFragment : BindingFragment<FragmentProfileBinding>(R.layout.fragmen
         initTestBtnOnClickListener()
         initPersonalityAdapter()
         initPersonalityOnClickListener()
+        observePersonalityPentagon()
     }
 
     private fun initPersonalityOnClickListener() {
@@ -88,6 +91,14 @@ class ProfileFragment : BindingFragment<FragmentProfileBinding>(R.layout.fragmen
                         ContextCompat.getColor(requireContext(), profileSet.colorText)
                     )
                 }
+            }
+        }
+    }
+
+    private fun observePersonalityPentagon() {
+        binding.cvProfilePersonalityPentagon.setContent {
+            HousTheme {
+                HousPersonalityPentagon(radiusList = listOf(5, 5, 5, 5, 5), homyType = HomyType.RED)
             }
         }
     }

--- a/app/src/main/java/hous/release/android/presentation/todo/detail/daily/DailyFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/detail/daily/DailyFragment.kt
@@ -15,6 +15,7 @@ import hous.release.android.presentation.todo.detail.TodoLimitDialog
 import hous.release.android.util.binding.BindingFragment
 import hous.release.android.util.component.DailyTab
 import hous.release.android.util.component.HousFloatingButton
+import hous.release.android.util.style.HousTheme
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
@@ -63,10 +64,12 @@ class DailyFragment : BindingFragment<FragmentDailyBinding>(R.layout.fragment_da
             .flowWithLifecycle(lifecycle)
             .onEach { uiState ->
                 binding.cvDailyWeekOfDayTab.setContent {
-                    DailyTab(
-                        currIndex = uiState.dailyTabIndex,
-                        setCurrIndex = todoDetailViewModel::setDailyTabIndex
-                    )
+                    HousTheme {
+                        DailyTab(
+                            currIndex = uiState.dailyTabIndex,
+                            setCurrIndex = todoDetailViewModel::setDailyTabIndex
+                        )
+                    }
                 }
                 binding.vpDailyTodos.currentItem = uiState.dailyTabIndex
             }

--- a/app/src/main/java/hous/release/android/presentation/todo/main/TodoFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/main/TodoFragment.kt
@@ -14,7 +14,9 @@ import hous.release.android.R
 import hous.release.android.databinding.FragmentToDoBinding
 import hous.release.android.presentation.todo.detail.TodoDetailActivity
 import hous.release.android.util.binding.BindingFragment
+import hous.release.android.util.component.RoundedLinearIndicatorWithHomie
 import hous.release.android.util.component.TodoMainEmpty
+import hous.release.android.util.style.HousTheme
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
@@ -50,10 +52,12 @@ class TodoFragment : BindingFragment<FragmentToDoBinding>(R.layout.fragment_to_d
             .flowWithLifecycle(lifecycle)
             .onEach { toDoUiState ->
                 binding.cvToDoProgress.setContent {
-                    if (toDoUiState.myTodosCount == 0 && toDoUiState.ourTodosCount == 0) {
-                        TodoMainEmpty()
-                    } else {
-                        RoundedLinearIndicatorWithHomie(currentProgress = toDoUiState.progress)
+                    HousTheme {
+                        if (toDoUiState.myTodosCount == 0 && toDoUiState.ourTodosCount == 0) {
+                            TodoMainEmpty()
+                        } else {
+                            RoundedLinearIndicatorWithHomie(currentProgress = toDoUiState.progress)
+                        }
                     }
                 }
                 myToDoAdapter?.submitList(toDoUiState.myTodos)

--- a/app/src/main/java/hous/release/android/util/component/DailyTap.kt
+++ b/app/src/main/java/hous/release/android/util/component/DailyTap.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import hous.release.android.R
+import hous.release.android.util.style.HousTheme
 
 @Composable
 fun DailyTab(
@@ -66,6 +67,7 @@ private fun DailyTapItem(
             ) else Modifier.clickable { setCurrIndex(index) }
                 .padding(vertical = 10.dp, horizontal = 13.dp),
             text = weekOfDay,
+            style = HousTheme.typography.b2,
             color = colorResource(id = if (index == currIndex) R.color.hous_white else R.color.hous_g_5)
         )
         Spacer(modifier = Modifier.height(12.dp))

--- a/app/src/main/java/hous/release/android/util/component/HomieMessageFrame.kt
+++ b/app/src/main/java/hous/release/android/util/component/HomieMessageFrame.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.graphics.drawOutline
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.unit.Dp
-import hous.release.android.presentation.todo.main.HomiesPosition
 
 fun DrawScope.drawMessageShape(
     side: Dp,

--- a/app/src/main/java/hous/release/android/util/component/HousBadge.kt
+++ b/app/src/main/java/hous/release/android/util/component/HousBadge.kt
@@ -20,17 +20,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.Font
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontStyle
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import hous.release.android.R
+import hous.release.android.util.style.HousTheme
 import hous.release.domain.entity.Badge
 import hous.release.domain.entity.BadgeState
 
@@ -54,32 +49,14 @@ fun HousBadge(
         Text(
             text = badge.name,
             color = colorResource(id = R.color.hous_g_7),
-            style = TextStyle(
-                fontFamily = FontFamily(Font(R.font.spoqa_han_sans_neo_medium)),
-                fontWeight = FontWeight.Normal,
-                fontSize = dpToSp(13.dp),
-                letterSpacing = (-0.02).sp,
-                lineHeight = 19.5.sp
-            ),
+            style = HousTheme.typography.b3,
             textAlign = TextAlign.Center
         )
         Spacer(modifier = Modifier.height(2.dp))
         Text(
             text = badge.description,
             color = colorResource(id = R.color.hous_g_3),
-            style = TextStyle(
-                fontFamily = FontFamily(
-                    Font(
-                        R.font.spoqa_han_sans_neo_medium,
-                        FontWeight.W500,
-                        FontStyle.Normal
-                    )
-                ),
-                fontWeight = FontWeight.Normal,
-                fontSize = dpToSp(12.dp),
-                letterSpacing = (-0.02).sp,
-                lineHeight = 16.sp
-            ),
+            style = HousTheme.typography.description,
             textAlign = TextAlign.Center
         )
     }
@@ -134,19 +111,7 @@ private fun HousBadgeImage(
                         text = "대표배지로\n설정됨",
                         color = colorResource(id = R.color.hous_white),
                         textAlign = TextAlign.Center,
-                        style = TextStyle(
-                            fontFamily = FontFamily(
-                                Font(
-                                    R.font.spoqa_han_sans_neo_medium,
-                                    FontWeight.W500,
-                                    FontStyle.Normal
-                                )
-                            ),
-                            fontWeight = FontWeight.Normal,
-                            fontSize = dpToSp(12.dp),
-                            letterSpacing = (-0.02).sp,
-                            lineHeight = 16.sp
-                        )
+                        style = HousTheme.typography.description
                     )
                 }
             }
@@ -174,19 +139,7 @@ private fun CheckedRepresentationBadge(
         Text(
             text = stringResource(R.string.badge_checked),
             color = colorResource(id = R.color.hous_white),
-            style = TextStyle(
-                fontFamily = FontFamily(
-                    Font(
-                        R.font.spoqa_han_sans_neo_medium,
-                        FontWeight.W500,
-                        FontStyle.Normal
-                    )
-                ),
-                fontWeight = FontWeight.Normal,
-                fontSize = dpToSp(12.dp),
-                letterSpacing = (-0.02).sp,
-                lineHeight = 16.sp
-            )
+            style = HousTheme.typography.description
         )
     }
 }

--- a/app/src/main/java/hous/release/android/util/component/MemberTap.kt
+++ b/app/src/main/java/hous/release/android/util/component/MemberTap.kt
@@ -22,13 +22,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.Font
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import hous.release.android.R
+import hous.release.android.util.style.HousTheme
 import hous.release.domain.entity.HomyType
 import hous.release.domain.entity.response.MemberTodoContent
 
@@ -38,19 +34,21 @@ fun MemberTodoTap(
     members: List<MemberTodoContent>,
     setCurrIndex: (Int) -> Unit
 ) {
-    LazyRow(
-        modifier = Modifier
-            .fillMaxWidth(),
-        contentPadding = PaddingValues(horizontal = 16.dp),
-        horizontalArrangement = Arrangement.spacedBy(28.dp)
-    ) {
-        itemsIndexed(members) { index, item ->
-            MemberTapItem(
-                member = item,
-                index = index,
-                currIndex = currIndex,
-                setCurrIndex = setCurrIndex
-            )
+    HousTheme {
+        LazyRow(
+            modifier = Modifier
+                .fillMaxWidth(),
+            contentPadding = PaddingValues(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(28.dp)
+        ) {
+            itemsIndexed(members) { index, item ->
+                MemberTapItem(
+                    member = item,
+                    index = index,
+                    currIndex = currIndex,
+                    setCurrIndex = setCurrIndex
+                )
+            }
         }
     }
 }
@@ -92,13 +90,7 @@ private fun MemberTapItem(
         Spacer(modifier = Modifier.height(5.dp))
         Text(
             text = member.userName,
-            style = TextStyle(
-                fontFamily = FontFamily(Font(R.font.spoqa_han_sans_neo)),
-                fontWeight = FontWeight.Normal,
-                fontSize = dpToSp(dp = 12.dp),
-                letterSpacing = (-0.3).sp,
-                lineHeight = 19.sp
-            ),
+            style = HousTheme.typography.description,
             color = colorResource(id = if (index == currIndex) R.color.hous_black else R.color.hous_g_5)
         )
         Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/hous/release/android/util/component/Pentagon.kt
+++ b/app/src/main/java/hous/release/android/util/component/Pentagon.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.unit.dp
 import hous.release.android.R
 import hous.release.android.util.style.HousTheme
 import hous.release.domain.entity.HomyType
+import hous.release.domain.entity.TestScore
 import kotlin.math.cos
 import kotlin.math.sin
 import kotlinx.coroutines.delay
@@ -51,14 +52,14 @@ import kotlinx.coroutines.delay
 @Composable
 private fun HousPersonalityPentagonPreview() {
     HousPersonalityPentagon(
-        radiusList = listOf(5, 5, 5, 5, 5),
+        testScore = TestScore(5, 5, 5, 5, 5),
         homyType = HomyType.BLUE
     )
 }
 
 @Composable
 fun HousPersonalityPentagon(
-    radiusList: List<Int>,
+    testScore: TestScore,
     homyType: HomyType
 ) {
     val backgroundColor = when (homyType) {
@@ -86,12 +87,12 @@ fun HousPersonalityPentagon(
         Box {
             HousPentagonText()
             HousPentagon(
-                radiusList = listOf(10, 10, 10, 10, 10),
+                testScore = TestScore(10, 10, 10, 10, 10),
                 duration = 2000,
                 backgroundColor = backgroundColor
             )
             HousPentagon(
-                radiusList = radiusList,
+                testScore = testScore,
                 duration = 4000,
                 backgroundColor = pentagonColor
             )
@@ -105,7 +106,7 @@ enum class AniState {
 
 @Composable
 private fun HousPentagon(
-    radiusList: List<Int>,
+    testScore: TestScore,
     duration: Int,
     @ColorRes backgroundColor: Int
 ) {
@@ -119,7 +120,7 @@ private fun HousPentagon(
         label = ""
     ) { state -> if (state == AniState.START) 0f else 1f }
     val pentagonColor = colorResource(id = backgroundColor)
-    val radiusFloatList = radiusList.toFloatList()
+    val radiusFloatList = testScore.toFloatList()
 
     Canvas(modifier = Modifier.fillMaxSize()) {
         drawIntoCanvas { canvas ->
@@ -174,7 +175,7 @@ private fun HousPentagonText() {
     var textVisible by remember { mutableStateOf(false) }
     val currentAngle = -0.5 * Math.PI
     val angle = 2.0 * Math.PI / 5.0f
-    val radiusList = listOf(12, 13, 13, 13, 13).toFloatList()
+    val radiusList = TestScore(12, 13, 13, 13, 13).toFloatList()
     LaunchedEffect(true) {
         delay(10)
         textVisible = true
@@ -212,12 +213,3 @@ private fun HousPentagonText() {
         }
     }
 }
-
-private fun List<Int>.toFloatList(): List<Float> = listOf(
-    (this[0] * 22 + 36).toFloat(),
-    (this[4] * 22 + 36).toFloat(),
-    (this[3] * 22 + 36).toFloat(),
-    (this[2] * 22 + 36).toFloat(),
-    (this[1] * 22 + 36).toFloat(),
-    (this[0] * 22 + 36).toFloat()
-)

--- a/app/src/main/java/hous/release/android/util/component/Pentagon.kt
+++ b/app/src/main/java/hous/release/android/util/component/Pentagon.kt
@@ -37,20 +37,15 @@ import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringArrayResource
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.Font
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontStyle
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import hous.release.android.R
+import hous.release.android.util.style.HousTheme
 import hous.release.domain.entity.HomyType
-import kotlinx.coroutines.delay
 import kotlin.math.cos
 import kotlin.math.sin
+import kotlinx.coroutines.delay
 
 @Preview(showBackground = true)
 @Composable
@@ -208,19 +203,7 @@ private fun HousPentagonText() {
                                 (center.x + (radiusPxList[i] * cos(currentAngle + angle * i)).toFloat() + xSite[i]).toDp(),
                                 (center.y + (radiusPxList[i] * sin(currentAngle + angle * i)).toFloat() + ySite[i]).toDp()
                             ),
-                        style = TextStyle(
-                            fontFamily = FontFamily(
-                                Font(
-                                    R.font.spoqa_han_sans_neo_medium,
-                                    FontWeight.W500,
-                                    FontStyle.Normal
-                                )
-                            ),
-                            fontWeight = FontWeight.Normal,
-                            fontSize = dpToSp(12.dp),
-                            letterSpacing = (-0.02).sp,
-                            lineHeight = 16.sp
-                        ),
+                        style = HousTheme.typography.description,
                         color = colorResource(id = R.color.hous_g_5),
                         textAlign = TextAlign.Center
                     )

--- a/app/src/main/java/hous/release/android/util/component/PersonalityResultImage.kt
+++ b/app/src/main/java/hous/release/android/util/component/PersonalityResultImage.kt
@@ -1,0 +1,75 @@
+package hous.release.android.util.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import hous.release.android.R
+import hous.release.android.util.style.HousTheme
+import hous.release.domain.entity.HomyType
+
+@Preview(showBackground = true)
+@Composable
+fun PersonalityResultImagePreview() {
+    HousTheme {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            PersonalityResultImage(
+                HomyType.BLUE,
+                imageUrl = "drawable.ic_tutorial_1"
+            )
+        }
+    }
+}
+
+@Composable
+fun PersonalityResultImage(
+    homyType: HomyType,
+    imageUrl: String
+) {
+    val shadowColor = when (homyType) {
+        HomyType.YELLOW -> R.color.hous_yellow
+        HomyType.RED -> R.color.hous_red
+        HomyType.BLUE -> R.color.hous_blue
+        HomyType.PURPLE -> R.color.hous_purple
+        HomyType.GREEN -> R.color.hous_green
+        HomyType.GRAY -> R.color.hous_g_1
+    }
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 40.dp, vertical = 20.dp)
+            .aspectRatio(1.0f)
+            .shadow(
+                ambientColor = colorResource(shadowColor),
+                spotColor = colorResource(shadowColor),
+                elevation = 10.dp,
+                shape = RoundedCornerShape(20.dp)
+            ),
+        elevation = 10.dp,
+        shape = RoundedCornerShape(20.dp)
+    ) {
+        AsyncImage(
+            model = imageUrl,
+            contentDescription = null,
+            placeholder = painterResource(id = R.drawable.ic_tutorial_1),
+            contentScale = ContentScale.Crop
+        )
+    }
+}

--- a/app/src/main/java/hous/release/android/util/component/ToDoProgressBar.kt
+++ b/app/src/main/java/hous/release/android/util/component/ToDoProgressBar.kt
@@ -1,4 +1,4 @@
-package hous.release.android.presentation.todo.main
+package hous.release.android.util.component
 
 import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.animateDpAsState
@@ -22,17 +22,10 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.Font
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import hous.release.android.R
-import hous.release.android.util.component.RoundedLinearIndicator
-import hous.release.android.util.component.dpToSp
-import hous.release.android.util.component.drawMessageShape
+import hous.release.android.util.style.HousTheme
 
 enum class HomiesPosition {
     START, LEFT, RIGHT, END
@@ -134,13 +127,7 @@ private fun MoveHomieWithMessage(
                 .padding(messagePaddingValue),
             text = homiesMessage,
             color = colorResource(id = R.color.hous_g_5),
-            style = TextStyle(
-                fontFamily = FontFamily(Font(R.font.spoqa_han_sans_neo_medium)),
-                fontWeight = FontWeight.Normal,
-                fontSize = dpToSp(dp = 13.dp),
-                letterSpacing = (-0.02).sp,
-                lineHeight = 6.5.sp
-            )
+            style = HousTheme.typography.description
         )
         Image(
             modifier = Modifier.absoluteOffset(x = maxWidth.times(progress).minus(homiesSite)),

--- a/app/src/main/java/hous/release/android/util/component/TodoMainEmpty.kt
+++ b/app/src/main/java/hous/release/android/util/component/TodoMainEmpty.kt
@@ -1,7 +1,12 @@
 package hous.release.android.util.component
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -9,15 +14,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.Font
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import hous.release.android.R
+import hous.release.android.util.style.HousTheme
 
 @Composable
 fun TodoMainEmpty() {
@@ -39,13 +40,7 @@ fun TodoMainEmpty() {
                 text = stringResource(R.string.todo_main_empty_progress),
                 textAlign = TextAlign.Center,
                 color = colorResource(id = R.color.hous_g_5),
-                style = TextStyle(
-                    fontFamily = FontFamily(Font(R.font.spoqa_han_sans_neo_medium)),
-                    fontWeight = FontWeight.Normal,
-                    fontSize = dpToSp(dp = 12.dp),
-                    letterSpacing = (-0.02).sp,
-                    lineHeight = 3.6.sp
-                )
+                style = HousTheme.typography.description,
             )
             Spacer(modifier = Modifier.height(13.dp))
             RoundedLinearIndicator(

--- a/app/src/main/java/hous/release/android/util/style/Theme.kt
+++ b/app/src/main/java/hous/release/android/util/style/Theme.kt
@@ -1,0 +1,37 @@
+package hous.release.android.util.style
+
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
+
+private val LocalHousTypography = staticCompositionLocalOf<HousTypography> {
+    error("No SoptTypography provided")
+}
+
+object HousTheme {
+    val typography: HousTypography @Composable get() = LocalHousTypography.current
+}
+
+@Composable
+fun ProvideHousTypography(
+    typography: HousTypography,
+    content: @Composable () -> Unit
+) {
+    val provideTypography = remember { typography.copy() }
+    CompositionLocalProvider(
+        LocalHousTypography provides provideTypography,
+        content = content
+    )
+}
+
+@Composable
+fun HousTheme(
+    content: @Composable () -> Unit
+) {
+    val typography = HousTypography()
+    ProvideHousTypography(typography = typography) {
+        MaterialTheme(content = content)
+    }
+}

--- a/app/src/main/java/hous/release/android/util/style/Type.kt
+++ b/app/src/main/java/hous/release/android/util/style/Type.kt
@@ -90,49 +90,49 @@ fun HousTypography(): HousTypography {
             fontWeight = FontWeight.Bold,
             fontSize = dpToSp(dp = 28.dp),
             letterSpacing = (-0.01).sp,
-            lineHeight = 8.4.sp
+            lineHeight = 36.4.sp
         ),
         h2 = TextStyle(
             fontFamily = spoqaHanSansNeo,
             fontWeight = FontWeight.Bold,
             fontSize = dpToSp(22.dp),
             letterSpacing = (-0.01).sp,
-            lineHeight = 6.6.sp
+            lineHeight = 28.6.sp
         ),
         h3 = TextStyle(
             fontFamily = spoqaHanSansNeo,
             fontWeight = FontWeight.Bold,
             fontSize = dpToSp(20.dp),
             letterSpacing = (-0.02).sp,
-            lineHeight = 8.sp
+            lineHeight = 28.sp
         ),
         h4 = TextStyle(
             fontFamily = spoqaHanSansNeo,
             fontWeight = FontWeight.Bold,
             fontSize = dpToSp(18.dp),
             letterSpacing = (-0.02).sp,
-            lineHeight = 5.4.sp
+            lineHeight = 23.4.sp
         ),
         b1 = TextStyle(
             fontFamily = spoqaHanSansNeoMedium,
             fontWeight = FontWeight.Normal,
             fontSize = dpToSp(16.dp),
             letterSpacing = (-0.02).sp,
-            lineHeight = 8.sp
+            lineHeight = 24.sp
         ),
         b2 = TextStyle(
             fontFamily = spoqaHanSansNeoMedium,
             fontWeight = FontWeight.Normal,
             fontSize = dpToSp(14.dp),
             letterSpacing = (-0.02).sp,
-            lineHeight = 7.sp
+            lineHeight = 21.sp
         ),
         b3 = TextStyle(
             fontFamily = spoqaHanSansNeoMedium,
             fontWeight = FontWeight.Normal,
             fontSize = dpToSp(13.dp),
             letterSpacing = (-0.02).sp,
-            lineHeight = 6.5.sp
+            lineHeight = 19.5.sp
         ),
         description = TextStyle(
             fontFamily = spoqaHanSansNeoMedium,

--- a/app/src/main/java/hous/release/android/util/style/Type.kt
+++ b/app/src/main/java/hous/release/android/util/style/Type.kt
@@ -1,0 +1,145 @@
+package hous.release.android.util.style
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import hous.release.android.R
+import hous.release.android.util.component.dpToSp
+
+private val spoqaHanSansNeo = FontFamily(
+    Font(
+        R.font.spoqa_han_sans_neo_bold,
+        FontWeight.W700,
+        FontStyle.Normal
+    )
+)
+
+private val spoqaHanSansNeoMedium = FontFamily(
+    Font(
+        R.font.spoqa_han_sans_neo_medium_f,
+        FontWeight.W500,
+        FontStyle.Normal
+    )
+)
+
+@Stable
+class HousTypography internal constructor(
+    h1: TextStyle,
+    h2: TextStyle,
+    h3: TextStyle,
+    h4: TextStyle,
+    b1: TextStyle,
+    b2: TextStyle,
+    b3: TextStyle,
+    description: TextStyle
+) {
+    var h1: TextStyle by mutableStateOf(h1)
+        private set
+    var h2: TextStyle by mutableStateOf(h2)
+        private set
+    var h3: TextStyle by mutableStateOf(h3)
+        private set
+    var h4: TextStyle by mutableStateOf(h4)
+        private set
+    var b1: TextStyle by mutableStateOf(b1)
+        private set
+    var b2: TextStyle by mutableStateOf(b2)
+        private set
+    var b3: TextStyle by mutableStateOf(b3)
+        private set
+    var description: TextStyle by mutableStateOf(description)
+        private set
+
+    fun copy(
+        h1: TextStyle = this.h1,
+        h2: TextStyle = this.h2,
+        h3: TextStyle = this.h3,
+        h4: TextStyle = this.h4,
+        b1: TextStyle = this.b1,
+        b2: TextStyle = this.b2,
+        b3: TextStyle = this.b3,
+        description: TextStyle = this.description
+    ): HousTypography = HousTypography(h1, h2, h3, h4, b1, b2, b3, description)
+
+    fun update(other: HousTypography) {
+        h1 = other.h1
+        h2 = other.h2
+        h3 = other.h3
+        h4 = other.h4
+        b1 = other.b1
+        b2 = other.b2
+        b3 = other.b3
+        description = other.description
+    }
+}
+
+@Composable
+fun HousTypography(): HousTypography {
+    return HousTypography(
+        h1 = TextStyle(
+            fontFamily = spoqaHanSansNeo,
+            fontWeight = FontWeight.Bold,
+            fontSize = dpToSp(dp = 28.dp),
+            letterSpacing = (-0.01).sp,
+            lineHeight = 8.4.sp
+        ),
+        h2 = TextStyle(
+            fontFamily = spoqaHanSansNeo,
+            fontWeight = FontWeight.Bold,
+            fontSize = dpToSp(22.dp),
+            letterSpacing = (-0.01).sp,
+            lineHeight = 6.6.sp
+        ),
+        h3 = TextStyle(
+            fontFamily = spoqaHanSansNeo,
+            fontWeight = FontWeight.Bold,
+            fontSize = dpToSp(20.dp),
+            letterSpacing = (-0.02).sp,
+            lineHeight = 8.sp
+        ),
+        h4 = TextStyle(
+            fontFamily = spoqaHanSansNeo,
+            fontWeight = FontWeight.Bold,
+            fontSize = dpToSp(18.dp),
+            letterSpacing = (-0.02).sp,
+            lineHeight = 5.4.sp
+        ),
+        b1 = TextStyle(
+            fontFamily = spoqaHanSansNeoMedium,
+            fontWeight = FontWeight.Normal,
+            fontSize = dpToSp(16.dp),
+            letterSpacing = (-0.02).sp,
+            lineHeight = 8.sp
+        ),
+        b2 = TextStyle(
+            fontFamily = spoqaHanSansNeoMedium,
+            fontWeight = FontWeight.Normal,
+            fontSize = dpToSp(14.dp),
+            letterSpacing = (-0.02).sp,
+            lineHeight = 7.sp
+        ),
+        b3 = TextStyle(
+            fontFamily = spoqaHanSansNeoMedium,
+            fontWeight = FontWeight.Normal,
+            fontSize = dpToSp(13.dp),
+            letterSpacing = (-0.02).sp,
+            lineHeight = 6.5.sp
+        ),
+        description = TextStyle(
+            fontFamily = spoqaHanSansNeoMedium,
+            fontWeight = FontWeight.Normal,
+            fontSize = dpToSp(12.dp),
+            letterSpacing = (-0.02).sp,
+            lineHeight = 3.6.sp
+        )
+    )
+}

--- a/app/src/main/java/hous/release/android/util/style/Type.kt
+++ b/app/src/main/java/hous/release/android/util/style/Type.kt
@@ -139,7 +139,7 @@ fun HousTypography(): HousTypography {
             fontWeight = FontWeight.Normal,
             fontSize = dpToSp(12.dp),
             letterSpacing = (-0.02).sp,
-            lineHeight = 3.6.sp
+            lineHeight = 15.6.sp
         )
     )
 }

--- a/app/src/main/res/layout/activity_personality_result.xml
+++ b/app/src/main/res/layout/activity_personality_result.xml
@@ -95,35 +95,26 @@
                     tools:text="슈퍼 팔로워 셋돌이"
                     tools:textColor="@color/hous_red" />
 
-                <ImageView
-                    android:id="@+id/iv_personality_result_image"
-                    setImage="@{vm.resultData.imageUrl}"
-                    android:layout_width="0dp"
-                    android:layout_height="0dp"
-                    android:layout_gravity="center"
-                    android:layout_marginHorizontal="39dp"
-                    android:layout_marginTop="24dp"
-                    android:background="@drawable/shape_white_fill_20_rect"
-                    android:elevation="10dp"
-                    android:outlineSpotShadowColor="@color/hous_red"
-                    android:padding="14dp"
-                    app:layout_constraintDimensionRatio="1"
+                <androidx.compose.ui.platform.ComposeView
+                    android:id="@+id/cv_personality_result_image"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="14dp"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_personality_result_name"
-                    tools:src="@drawable/ic_tutorial_1" />
+                    app:layout_constraintTop_toBottomOf="@id/tv_personality_result_name" />
 
                 <TextView
                     android:id="@+id/tv_personality_result_title"
                     personalityResultColor="@{vm.resultData.color.name()}"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="36dp"
+                    android:layout_marginTop="26dp"
                     android:text="@{vm.resultData.title}"
                     android:textAppearance="@style/H4"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/iv_personality_result_image"
+                    app:layout_constraintTop_toBottomOf="@id/cv_personality_result_image"
                     tools:text="오히려 좋아~ 가보자고!"
                     tools:textColor="@color/hous_red" />
 

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -251,27 +251,31 @@
                             android:layout_height="280dp"
                             app:layout_constraintTop_toBottomOf="@+id/tv_profile_personality" />
 
-                        <TextView
-                            android:id="@+id/tv_profile_personality_detail"
+                        <LinearLayout
+                            android:id="@+id/ll_profile_personality_detail"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:layout_marginEnd="4dp"
-                            android:paddingVertical="8dp"
-                            android:paddingStart="16dp"
-                            android:paddingEnd="3dp"
-                            android:text="@string/profile_personality_detail"
-                            app:layout_constraintEnd_toStartOf="@+id/iv_profile_personality_detail"
-                            app:layout_constraintTop_toTopOf="parent" />
-
-                        <ImageView
-                            android:id="@+id/iv_profile_personality_detail"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginEnd="16dp"
-                            android:src="@drawable/ic_profile_next"
-                            app:layout_constraintBottom_toBottomOf="@+id/tv_profile_personality_detail"
+                            android:gravity="center"
                             app:layout_constraintEnd_toEndOf="parent"
-                            app:layout_constraintTop_toTopOf="@+id/tv_profile_personality_detail" />
+                            app:layout_constraintTop_toTopOf="parent">
+
+                            <TextView
+                                android:id="@+id/tv_profile_personality_detail"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginEnd="4dp"
+                                android:paddingVertical="8dp"
+                                android:paddingStart="16dp"
+                                android:paddingEnd="3dp"
+                                android:text="@string/profile_personality_detail" />
+
+                            <ImageView
+                                android:id="@+id/iv_profile_personality_detail"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginEnd="16dp"
+                                android:src="@drawable/ic_profile_next" />
+                        </LinearLayout>
 
                         <androidx.recyclerview.widget.RecyclerView
                             android:id="@+id/rv_personality_info"

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -17,6 +17,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/hous_white"
+        android:paddingBottom="12dp"
         tools:context=".presentation.profile.ProfileFragment">
 
         <androidx.constraintlayout.widget.ConstraintLayout
@@ -211,84 +212,97 @@
                     android:background="@color/hous_g_0"
                     app:layout_constraintTop_toBottomOf="@id/tv_profile_introduction" />
 
-                <ImageView
-                    android:id="@+id/iv_profile_empty_tendency"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="28dp"
-                    android:layout_marginBottom="16dp"
-                    android:src="@drawable/ic_profile_empty_tendency"
-                    android:visibility="@{vm.isTest ? View.INVISIBLE : View.VISIBLE}"
-                    app:layout_constraintBottom_toTopOf="@id/tv_profile_tendency"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/view_profile" />
-
-                <TextView
-                    android:id="@+id/tv_profile_personality"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="19dp"
-                    android:textAppearance="@style/H2"
-                    android:visibility="@{vm.isTest ? View.VISIBLE : View.INVISIBLE}"
-                    app:layout_constraintStart_toStartOf="@id/view_profile"
-                    app:layout_constraintTop_toBottomOf="@id/view_profile"
-                    tools:text="@string/personality_red"
-                    tools:textColor="@color/hous_red" />
-
-                <TextView
-                    android:id="@+id/tv_profile_personality_detail"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:paddingVertical="16dp"
-                    android:paddingStart="16dp"
-                    android:paddingEnd="3dp"
-                    android:text="@string/profile_personality_detail"
-                    android:visibility="@{vm.isTest ? View.VISIBLE : View.INVISIBLE}"
-                    app:layout_constraintBottom_toBottomOf="@id/iv_profile_personality_detail"
-                    app:layout_constraintEnd_toStartOf="@id/iv_profile_personality_detail"
-                    app:layout_constraintTop_toTopOf="@id/iv_profile_personality_detail" />
-
-                <ImageView
-                    android:id="@+id/iv_profile_personality_detail"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="32dp"
-                    android:src="@drawable/ic_profile_next"
-                    android:visibility="@{vm.isTest ? View.VISIBLE : View.INVISIBLE}"
-                    app:layout_constraintEnd_toEndOf="@id/view_profile"
-                    app:layout_constraintTop_toBottomOf="@id/view_profile" />
-
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/rv_personality_info"
+                <FrameLayout
+                    android:id="@+id/fl_profile_personality"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="32dp"
-                    android:clipToPadding="false"
-                    android:orientation="horizontal"
-                    android:overScrollMode="always"
-                    android:scrollbarAlwaysDrawVerticalTrack="true"
-                    android:scrollbarFadeDuration="0"
-                    android:scrollbarSize="2dp"
-                    android:scrollbarStyle="outsideInset"
-                    android:scrollbarThumbHorizontal="@drawable/shape_g3_fill_2_rect"
-                    android:scrollbars="horizontal"
-                    android:visibility="@{vm.isTest ? View.VISIBLE : View.INVISIBLE}"
-                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                    app:layout_constraintBottom_toTopOf="@id/tv_profile_tendency"
-                    tools:listitem="@layout/item_profile_personality" />
+                    app:layout_constraintTop_toBottomOf="@id/view_profile">
+
+                    <ImageView
+                        android:id="@+id/iv_profile_empty_tendency"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="top|center"
+                        android:layout_marginTop="28dp"
+                        android:src="@drawable/ic_profile_empty_tendency"
+                        android:visibility="@{vm.isTest ? View.GONE : View.VISIBLE}" />
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:id="@+id/cl_profile_has_personality"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="20dp"
+                        android:visibility="@{vm.isTest ? View.VISIBLE : View.GONE}">
+
+                        <TextView
+                            android:id="@+id/tv_profile_personality"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="16dp"
+                            android:textAppearance="@style/H2"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"
+                            tools:text="@string/personality_red"
+                            tools:textColor="@color/hous_red" />
+
+                        <androidx.compose.ui.platform.ComposeView
+                            android:id="@+id/cv_profile_personality_pentagon"
+                            android:layout_width="match_parent"
+                            android:layout_height="280dp"
+                            app:layout_constraintTop_toBottomOf="@+id/tv_profile_personality" />
+
+                        <TextView
+                            android:id="@+id/tv_profile_personality_detail"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginEnd="4dp"
+                            android:paddingVertical="8dp"
+                            android:paddingStart="16dp"
+                            android:paddingEnd="3dp"
+                            android:text="@string/profile_personality_detail"
+                            app:layout_constraintEnd_toStartOf="@+id/iv_profile_personality_detail"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                        <ImageView
+                            android:id="@+id/iv_profile_personality_detail"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginEnd="16dp"
+                            android:src="@drawable/ic_profile_next"
+                            app:layout_constraintBottom_toBottomOf="@+id/tv_profile_personality_detail"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintTop_toTopOf="@+id/tv_profile_personality_detail" />
+
+                        <androidx.recyclerview.widget.RecyclerView
+                            android:id="@+id/rv_personality_info"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:clipToPadding="false"
+                            android:orientation="horizontal"
+                            android:overScrollMode="always"
+                            android:scrollbarAlwaysDrawVerticalTrack="true"
+                            android:scrollbarFadeDuration="0"
+                            android:scrollbarSize="2dp"
+                            android:scrollbarStyle="outsideInset"
+                            android:scrollbarThumbHorizontal="@drawable/shape_g3_fill_2_rect"
+                            android:scrollbars="horizontal"
+                            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                            app:layout_constraintTop_toBottomOf="@+id/cv_profile_personality_pentagon"
+                            tools:listitem="@layout/item_profile_personality" />
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+                </FrameLayout>
 
                 <TextView
                     android:id="@+id/tv_profile_tendency"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="12dp"
+                    android:layout_marginTop="16dp"
                     android:text="@{vm.isTest ? @string/profile_not_my_personality : @string/profile_empty_personality}"
                     android:textAppearance="@style/B2"
                     android:textColor="@color/hous_g_6"
-                    app:layout_constraintBottom_toTopOf="@id/btn_profile_test_again"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/fl_profile_personality"
                     tools:text="@string/profile_empty_personality" />
 
                 <androidx.appcompat.widget.AppCompatButton
@@ -296,12 +310,13 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="16dp"
-                    android:layout_marginBottom="42dp"
+                    android:layout_marginTop="12dp"
                     android:background="@drawable/shape_black_fill_8_rect"
                     android:text="@{vm.isTest ? @string/profile_test_again : @string/profile_empty_go_test}"
                     android:textAppearance="@style/B1"
                     android:textColor="@color/hous_white"
-                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/tv_profile_tendency"
+                    tools:layout_editor_absoluteX="16dp"
                     tools:text="@string/profile_empty_go_test" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>

--- a/domain/src/main/java/hous/release/domain/entity/TestScore.kt
+++ b/domain/src/main/java/hous/release/domain/entity/TestScore.kt
@@ -6,4 +6,13 @@ data class TestScore(
     val clean: Int = 0,
     val smell: Int = 0,
     val introversion: Int = 0
-)
+) {
+    fun toFloatList(): List<Float> = listOf(
+        (light * 22 + 36).toFloat(),
+        (introversion * 22 + 36).toFloat(),
+        (smell * 22 + 36).toFloat(),
+        (clean * 22 + 36).toFloat(),
+        (noise * 22 + 36).toFloat(),
+        (light * 22 + 36).toFloat()
+    )
+}


### PR DESCRIPTION
## 관련 이슈
- closed #99 

https://user-images.githubusercontent.com/82709044/198970650-c249b99c-eb36-443c-9213-dc72f7e3a9dc.mp4

## 작업한 내용
- [x] 프로필 메인 뷰 내에 오각형 구현
- [x] 성향 결과 별 이미지에 elevation 추가
- [x] 대표 배지가 없을 경우 elevation 추가
- [x] compose theme 추가

## PR 포인트
- compose theme 추가 후 하드 코딩한 부분 전부 수정
    - [[ui] compose custom theme 구현](https://github.com/Hous-Release/hous-AOS/commit/27f47aca242fdf8c4875a07051943e549a4eaef0)
    - [[chore] theme 적용](https://github.com/Hous-Release/hous-AOS/commit/a6e9836583daf005091ad28905b9cf565feeb831)
    - [[fix] lineheight 수정](https://github.com/Hous-Release/hous-AOS/commit/6ff40b583713eafdeb6037181963ba0a3a19aefc)
- 프로필 메인 뷰 제약 수정
    - [[fix] 레이아웃 제약 수정](https://github.com/Hous-Release/hous-AOS/commit/5aa8ed038084f57932b19ddf22b01e366d3bdcd0)
- 프로필 메인 뷰 내에 오각형 구현 및 서버 연결
    - [[feat] 유저 성향 오각형 프로필 뷰 내에 구현](https://github.com/Hous-Release/hous-AOS/commit/15553ac058ae0f3eaaef8a1f7817fea33409b78a)
- 성향 결과 이미지 elevation 추가
    - [[ui] 성향 설명 이미지 elevation 추가](https://github.com/Hous-Release/hous-AOS/pull/100/commits/eb21d77be6a7f3e43b264837c7825dcbdfb74d0d)
