### PR TITLE
#110 [ui, feat] todo 수정 뷰/ 기능/서버연동 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     id("com.google.gms.google-services")
     id("org.jlleitschuh.gradle.ktlint") version ktlintVersion
     id("kotlin-parcelize")
+    id("androidx.navigation.safeargs.kotlin")
 }
 
 val properties = Properties()

--- a/app/src/main/java/hous/release/android/presentation/todo/add/AddToDoFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/add/AddToDoFragment.kt
@@ -5,8 +5,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.addCallback
-import androidx.annotation.ColorRes
-import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
@@ -29,7 +27,6 @@ class AddToDoFragment : BindingFragment<FragmentAddToDoBinding>(R.layout.fragmen
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.vm = viewModel
-        setStatusBarColor(colorRes = R.color.hous_white)
         initToDoUserScreen()
         initBackButtonListener()
         collectTodoName()
@@ -39,7 +36,6 @@ class AddToDoFragment : BindingFragment<FragmentAddToDoBinding>(R.layout.fragmen
     override fun onDestroyView() {
         super.onDestroyView()
         onBackPressedCallback.remove()
-        setStatusBarColor(colorRes = R.color.hous_g_1)
     }
 
     @SuppressLint("ClickableViewAccessibility")
@@ -69,11 +65,6 @@ class AddToDoFragment : BindingFragment<FragmentAddToDoBinding>(R.layout.fragmen
                 )
             }
         }
-    }
-
-    private fun setStatusBarColor(@ColorRes colorRes: Int) {
-        requireActivity().window.statusBarColor =
-            ContextCompat.getColor(requireActivity(), colorRes)
     }
 
     private fun collectTodoName() {

--- a/app/src/main/java/hous/release/android/presentation/todo/add/AddToDoVIewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/add/AddToDoVIewModel.kt
@@ -34,7 +34,7 @@ class AddToDoVIewModel @Inject constructor(
         }
     }
 
-    fun putTodo() = viewModelScope.launch {
+    override fun putTodo() = viewModelScope.launch {
         postAddToDoUseCase(
             isPushNotification = uiState.value.isPushNotification,
             todoUsers = uiState.value.selectedUsers,

--- a/app/src/main/java/hous/release/android/presentation/todo/detail/TodoBottomSheet.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/detail/TodoBottomSheet.kt
@@ -11,6 +11,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import hous.release.android.R
 import hous.release.android.databinding.DialogToDoBottomSheetBinding
+import hous.release.android.presentation.todo.detail.daily.DailyFragment
 import hous.release.android.presentation.todo.detail.daily.DailyFragment.Companion.TODO_ID
 import hous.release.android.util.dialog.ConfirmClickListener
 import hous.release.android.util.dialog.WarningDialogFragment
@@ -92,7 +93,10 @@ class TodoBottomSheet : BottomSheetDialogFragment() {
 
     private fun initEditButtonOnClickListener() {
         binding.tvToDoEdit.setOnClickListener {
-            /* todo 수정하기 뷰로 이동 */
+            dismiss()
+            requireArguments().getParcelable<ConfirmClickListener>(DailyFragment.TAG)
+                ?.onConfirmClick()
+                ?: Timber.e(getString(R.string.null_point_exception_to_do_bottom_sheet_dialog_argument))
         }
     }
 

--- a/app/src/main/java/hous/release/android/presentation/todo/detail/daily/DailyFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/detail/daily/DailyFragment.kt
@@ -15,6 +15,8 @@ import hous.release.android.presentation.todo.detail.TodoLimitDialog
 import hous.release.android.util.binding.BindingFragment
 import hous.release.android.util.component.DailyTab
 import hous.release.android.util.component.HousFloatingButton
+import hous.release.android.util.dialog.ConfirmClickListener
+import hous.release.android.util.extension.withArgs
 import hous.release.android.util.style.HousTheme
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -82,15 +84,17 @@ class DailyFragment : BindingFragment<FragmentDailyBinding>(R.layout.fragment_da
     }
 
     private fun showTodoBottomSheet(todoId: Int) {
-        TodoBottomSheet()
-            .apply {
-                val bundle = Bundle()
-                bundle.putInt(TODO_ID, todoId)
-                arguments = bundle
-            }
-            .also { todoBottomSheet ->
-                todoBottomSheet.show(childFragmentManager, this.javaClass.name)
-            }
+        TodoBottomSheet().withArgs {
+            putInt(TODO_ID, todoId)
+            putParcelable(
+                TAG,
+                ConfirmClickListener(confirmAction = {
+                    val action =
+                        DailyFragmentDirections.actionDailyFragmentToEditToDoFragment(todoId)
+                    findNavController().navigate(action)
+                })
+            )
+        }.show(childFragmentManager, this.javaClass.simpleName)
     }
 
     private fun initFloatingButton() {
@@ -106,6 +110,7 @@ class DailyFragment : BindingFragment<FragmentDailyBinding>(R.layout.fragment_da
     }
 
     companion object {
+        const val TAG = "navigate_To_EditTodoFragment"
         const val TODO_ID = "todo_id"
     }
 }

--- a/app/src/main/java/hous/release/android/presentation/todo/detail/member/MemberFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/detail/member/MemberFragment.kt
@@ -16,6 +16,8 @@ import hous.release.android.presentation.todo.detail.daily.DailyFragment
 import hous.release.android.util.binding.BindingFragment
 import hous.release.android.util.component.HousFloatingButton
 import hous.release.android.util.component.MemberTodoTap
+import hous.release.android.util.dialog.ConfirmClickListener
+import hous.release.android.util.extension.withArgs
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
@@ -32,6 +34,7 @@ class MemberFragment : BindingFragment<FragmentMemberBinding>(R.layout.fragment_
         initFinishOnClick()
         initFloatingButton()
     }
+
     override fun onResume() {
         super.onResume()
         todoDetailViewModel.fetchMemberToDos()
@@ -82,15 +85,17 @@ class MemberFragment : BindingFragment<FragmentMemberBinding>(R.layout.fragment_
     }
 
     private fun showTodoBottomSheet(todoId: Int) {
-        TodoBottomSheet()
-            .apply {
-                val bundle = Bundle()
-                bundle.putInt(DailyFragment.TODO_ID, todoId)
-                arguments = bundle
-            }
-            .also { todoBottomSheet ->
-                todoBottomSheet.show(childFragmentManager, this.javaClass.name)
-            }
+        TodoBottomSheet().withArgs {
+            putInt(DailyFragment.TODO_ID, todoId)
+            putParcelable(
+                DailyFragment.TAG,
+                ConfirmClickListener(confirmAction = {
+                    val action =
+                        MemberFragmentDirections.actionMemberFragmentToEditToDoFragment(todoId)
+                    findNavController().navigate(action)
+                })
+            )
+        }.show(childFragmentManager, this.javaClass.simpleName)
     }
 
     private fun initFloatingButton() {

--- a/app/src/main/java/hous/release/android/presentation/todo/edit/EditToDoFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/edit/EditToDoFragment.kt
@@ -51,6 +51,7 @@ class EditToDoFragment : BindingFragment<FragmentEditToDoBinding>(R.layout.fragm
             KeyBoardUtil.hide(requireActivity())
         }
         binding.composeViewEditToDo.setOnClickListener {
+            KeyBoardUtil.hide(requireActivity())
         }
     }
 
@@ -64,7 +65,7 @@ class EditToDoFragment : BindingFragment<FragmentEditToDoBinding>(R.layout.fragm
                 EditTodoUserScreen(
                     viewModel = viewModel,
                     finish = { findNavController().popBackStack() },
-                    name = getString(R.string.to_do_add_button),
+                    name = getString(R.string.to_do_save_button),
                     hideKeyBoard = ::hideKeyBoard
                 )
             }

--- a/app/src/main/java/hous/release/android/presentation/todo/edit/EditToDoFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/edit/EditToDoFragment.kt
@@ -1,0 +1,109 @@
+package hous.release.android.presentation.todo.edit
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.view.View
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.addCallback
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
+import dagger.hilt.android.AndroidEntryPoint
+import hous.release.android.R
+import hous.release.android.databinding.FragmentEditToDoBinding
+import hous.release.android.util.KeyBoardUtil
+import hous.release.android.util.binding.BindingFragment
+import hous.release.android.util.dialog.ConfirmClickListener
+import hous.release.android.util.dialog.WarningDialogFragment
+import hous.release.android.util.dialog.WarningType
+import hous.release.android.util.extension.repeatOnStarted
+import hous.release.android.util.extension.withArgs
+import hous.release.android.util.style.HousTheme
+
+@AndroidEntryPoint
+class EditToDoFragment : BindingFragment<FragmentEditToDoBinding>(R.layout.fragment_edit_to_do) {
+
+    private val viewModel by viewModels<EditToDoViewModel>()
+    private val safeArgs: EditToDoFragmentArgs by navArgs()
+    private lateinit var onBackPressedCallback: OnBackPressedCallback
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.vm = viewModel
+        passIdToViewModel()
+        initToDoUserScreen()
+        initBackButtonListener()
+        collectTodoName()
+        initEditTextClearFocus()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        onBackPressedCallback.remove()
+    }
+
+    private fun passIdToViewModel() {
+        val toDoId = safeArgs.todoId
+        viewModel.fetchEditTodoContent(toDoId)
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    private fun initEditTextClearFocus() {
+        binding.clEditToDo.setOnTouchListener { _, _ ->
+            KeyBoardUtil.hide(requireActivity())
+            return@setOnTouchListener false
+        }
+        binding.composeViewEditToDo.setOnTouchListener { _, _ ->
+            KeyBoardUtil.hide(requireActivity())
+            return@setOnTouchListener false
+        }
+    }
+
+    private fun hideKeyBoard() {
+        KeyBoardUtil.hide(requireActivity())
+    }
+
+    private fun initToDoUserScreen() {
+        binding.composeViewEditToDo.setContent {
+            HousTheme {
+                EditTodoUserScreen(
+                    viewModel = viewModel,
+                    finish = { findNavController().popBackStack() },
+                    name = getString(R.string.to_do_add_button),
+                    hideKeyBoard = ::hideKeyBoard
+                )
+            }
+        }
+    }
+
+    private fun collectTodoName() {
+        repeatOnStarted {
+            viewModel.todoName.collect {
+                viewModel.setToDoNameState(isBlank = viewModel.isBlankToDoName())
+            }
+        }
+    }
+
+    private fun initBackButtonListener() {
+        requireActivity().onBackPressedDispatcher.addCallback {
+            showOutDialog()
+        }.also { callback -> onBackPressedCallback = callback }
+
+        binding.btnEditToDoBack.setOnClickListener {
+            showOutDialog()
+        }
+    }
+
+    private fun showOutDialog() {
+        WarningDialogFragment().withArgs {
+            putSerializable(
+                WarningDialogFragment.WARNING_TYPE,
+                WarningType.WARNING_EDIT_TO_DO
+            )
+            putParcelable(
+                WarningDialogFragment.CONFIRM_ACTION,
+                ConfirmClickListener(confirmAction = { findNavController().popBackStack() })
+            )
+        }.show(childFragmentManager, WarningDialogFragment.DIALOG_WARNING)
+    }
+}

--- a/app/src/main/java/hous/release/android/presentation/todo/edit/EditToDoFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/edit/EditToDoFragment.kt
@@ -1,6 +1,5 @@
 package hous.release.android.presentation.todo.edit
 
-import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.View
 import androidx.activity.OnBackPressedCallback
@@ -47,15 +46,11 @@ class EditToDoFragment : BindingFragment<FragmentEditToDoBinding>(R.layout.fragm
         viewModel.fetchEditTodoContent(toDoId)
     }
 
-    @SuppressLint("ClickableViewAccessibility")
     private fun initEditTextClearFocus() {
-        binding.clEditToDo.setOnTouchListener { _, _ ->
+        binding.clEditToDo.setOnClickListener {
             KeyBoardUtil.hide(requireActivity())
-            return@setOnTouchListener false
         }
-        binding.composeViewEditToDo.setOnTouchListener { _, _ ->
-            KeyBoardUtil.hide(requireActivity())
-            return@setOnTouchListener false
+        binding.composeViewEditToDo.setOnClickListener {
         }
     }
 

--- a/app/src/main/java/hous/release/android/presentation/todo/edit/EditToDoUserScreen.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/edit/EditToDoUserScreen.kt
@@ -1,0 +1,26 @@
+package hous.release.android.presentation.todo.edit
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import hous.release.android.presentation.todo.viewmodel.UpdateToDoUiState
+import hous.release.android.util.component.TodoUserScreen
+import hous.release.android.util.extension.collectAsStateWithLifecycleRemember
+
+@Composable
+fun EditTodoUserScreen(
+    viewModel: EditToDoViewModel,
+    finish: () -> Boolean,
+    name: String,
+    hideKeyBoard: () -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycleRemember(UpdateToDoUiState())
+    TodoUserScreen(
+        uiState = uiState,
+        checkUser = viewModel::checkUser,
+        selectTodoDay = viewModel::selectTodoDay,
+        finish = finish,
+        name = name,
+        putToDo = viewModel::putTodo,
+        hideKeyBoard = hideKeyBoard
+    )
+}

--- a/app/src/main/java/hous/release/android/presentation/todo/edit/EditToDoViewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/edit/EditToDoViewModel.kt
@@ -1,0 +1,59 @@
+package hous.release.android.presentation.todo.edit
+
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import hous.release.android.presentation.our_rules.type.ButtonState
+import hous.release.android.presentation.todo.viewmodel.UpdateToDoViewModel
+import hous.release.domain.entity.ApiResult
+import hous.release.domain.usecase.GetEditTodoContentUseCase
+import hous.release.domain.usecase.PutEditToDoUseCase
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+class EditToDoViewModel @Inject constructor(
+    private val getEditTodoContentUseCase: GetEditTodoContentUseCase,
+    private val putEditToDoUseCase: PutEditToDoUseCase
+) :
+    UpdateToDoViewModel() {
+    private var todoId = -1
+    override fun putTodo() = viewModelScope.launch {
+        putEditToDoUseCase(
+            todoId = todoId,
+            isPushNotification = uiState.value.isPushNotification,
+            todoUsers = uiState.value.selectedUsers,
+            toDoName = todoName.value
+        ).collect { apiResult ->
+            when (apiResult) {
+                is ApiResult.Success -> Timber.i(apiResult.data)
+                is ApiResult.Error -> Timber.e(apiResult.msg)
+                is ApiResult.Empty -> Timber.e(IllegalArgumentException())
+            }
+        }
+    }
+
+    fun fetchEditTodoContent(todoId: Int) {
+        this.todoId = todoId
+        viewModelScope.launch {
+            getEditTodoContentUseCase(todoId).collect { apiResult ->
+                when (apiResult) {
+                    is ApiResult.Success -> _uiState.update { uiState ->
+                        val data = apiResult.data
+                        todoName.value = data.name
+                        uiState.copy(
+                            isPushNotification = data.isPushNotification,
+                            buttonState = ButtonState.ACTIVE,
+                            isBlankTodoName = false,
+                            todoUsers = data.todoUsers,
+                            selectedUsers = data.todoUsers.filter { it.isChecked }
+                        )
+                    }
+                    is ApiResult.Error -> Timber.e(apiResult.msg)
+                    is ApiResult.Empty -> Timber.i("empty View")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/hous/release/android/presentation/todo/viewmodel/UpdateToDoViewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/viewmodel/UpdateToDoViewModel.kt
@@ -3,6 +3,7 @@ package hous.release.android.presentation.todo.viewmodel
 import androidx.lifecycle.ViewModel
 import hous.release.android.presentation.our_rules.type.ButtonState
 import hous.release.domain.entity.response.ToDoUser
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -12,6 +13,7 @@ abstract class UpdateToDoViewModel : ViewModel() {
     protected var _uiState = MutableStateFlow(UpdateToDoUiState())
     val uiState = _uiState.asStateFlow()
 
+    abstract fun putTodo(): Job
     fun checkUser(userIdx: Int) {
         _uiState.update { uiState ->
             val newToDoUsers = uiState.todoUsers.mapIndexed { idx, toDoUser ->

--- a/app/src/main/res/layout/fragment_edit_to_do.xml
+++ b/app/src/main/res/layout/fragment_edit_to_do.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="vm"
+            type="hous.release.android.presentation.todo.edit.EditToDoViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_edit_to_do"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".presentation.todo.edit.EditToDoFragment">
+
+        <ImageButton
+            android:id="@+id/btn_edit_to_do_back"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:background="@null"
+            android:padding="14dp"
+            android:src="@drawable/ic_back_g5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageButton
+            android:id="@+id/btn_edit_to_do_push_notification"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:layout_marginEnd="3dp"
+            android:background="@null"
+            android:onClick="@{()->vm.changeNotificationState()}"
+            android:padding="16dp"
+            android:src="@drawable/selector_push_notification"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:notificationState="@{vm.uiState.isPushNotification}" />
+
+        <TextView
+            android:id="@+id/tv_edit_to_do_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:layout_marginEnd="8dp"
+            android:text="@string/to_do_edit_title"
+            android:textAppearance="@style/B1"
+            android:textColor="@color/hous_black"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_goneMarginEnd="6dp" />
+
+        <EditText
+            android:id="@+id/edt_to_do_edit"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="18dp"
+            android:layout_marginTop="32dp"
+            android:background="@null"
+            android:hint="@string/to_do_text_field_hint"
+            android:importantForAutofill="no"
+            android:inputType="text"
+            android:maxLength="15"
+            android:text="@={vm.todoName}"
+            android:textAlignment="textStart"
+            android:textAppearance="@style/B2"
+            android:textColor="@color/hous_black"
+            android:textColorHint="@color/hous_g_5"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_edit_to_do_title" />
+
+        <View
+            android:id="@+id/view_to_do_edit"
+            android:layout_width="match_parent"
+            android:layout_height="2dp"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="8dp"
+            android:background="@{vm.todoName.length() == 0 ? @color/hous_g_3 : @color/hous_blue }"
+            app:layout_constraintTop_toBottomOf="@id/edt_to_do_edit"
+            tools:background="@color/hous_g_3" />
+
+        <TextView
+            android:id="@+id/tv_to_do_cnt"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@{@string/to_do_name_count(vm.todoName.length)}"
+            android:textAppearance="@style/Description"
+            android:textColor="@color/hous_g_5"
+            app:layout_constraintEnd_toEndOf="@id/view_to_do_edit"
+            app:layout_constraintTop_toBottomOf="@id/view_to_do_edit"
+            tools:text="7/15" />
+
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/compose_view_edit_to_do"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_to_do_cnt" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/navigation/nav_todo_detail.xml
+++ b/app/src/main/res/navigation/nav_todo_detail.xml
@@ -17,6 +17,9 @@
         <action
             android:id="@+id/action_dailyFragment_to_addToDoFragment"
             app:destination="@id/addToDoFragment" />
+        <action
+            android:id="@+id/action_dailyFragment_to_editToDoFragment"
+            app:destination="@id/editToDoFragment" />
     </fragment>
     <fragment
         android:id="@+id/memberFragment"
@@ -31,10 +34,22 @@
         <action
             android:id="@+id/action_memberFragment_to_addToDoFragment"
             app:destination="@id/addToDoFragment" />
+        <action
+            android:id="@+id/action_memberFragment_to_editToDoFragment"
+            app:destination="@id/editToDoFragment" />
     </fragment>
     <fragment
         android:id="@+id/addToDoFragment"
         android:name="hous.release.android.presentation.todo.add.AddToDoFragment"
         android:label="AddToDoFragment"
         tools:layout="@layout/fragment_add_to_do" />
+    <fragment
+        android:id="@+id/editToDoFragment"
+        android:name="hous.release.android.presentation.todo.edit.EditToDoFragment"
+        android:label="EditToDoFragment"
+        tools:layout="@layout/fragment_edit_to_do" >
+        <argument
+            android:name="todoId"
+            app:argType="integer" />
+    </fragment>
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="null_point_exception_detail">NullPointException occurs - %s : %s</string>
     <string name="null_point_exception_detail_two_item">NullPointException occurs - %s : %s, %s : %s</string>
     <string name="null_point_exception_warning_dialog_argument">"WarningDialogFragment에 필요한 arguments에 안들어옴"</string>
+    <string name="null_point_exception_to_do_bottom_sheet_dialog_argument">"ToDoBottomSheetDialogFragment에 필요한 arguments에 안들어옴"</string>
     <string name="binding_error">Binding not initialized to reference the view.</string>
     <string name="back_btn_image_desc">뒤로가기 버튼</string>
     <string name="finish_app_toast_msg">뒤로가기를 한 번 더 누르시면 앱이 종료돼요!</string>
@@ -299,5 +300,7 @@
     <string name="personality_result_complete">완료</string>
     <string name="personality_result_good">찰떡궁합</string>
     <string name="personality_result_bad">맞춰가요</string>
+    <!-- TODO: Remove or change this placeholder text -->
+    <string name="hello_blank_fragment">Hello blank fragment</string>
 
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ buildscript {
 }
 
 plugins {
+    id("androidx.navigation.safeargs.kotlin") version Deps.AndroidX.nav_version apply false
     id("com.android.application") version "7.2.0" apply false
     id("com.android.library") version "7.2.0" apply false
     id("org.jetbrains.kotlin.android") version "1.7.10" apply false

--- a/buildSrc/src/main/java/Deps.kt
+++ b/buildSrc/src/main/java/Deps.kt
@@ -15,9 +15,9 @@ object Deps {
     object AndroidX {
         const val kakao_login = "com.kakao.sdk:v2-user:2.11.0"
         const val hilt_navigation = "androidx.hilt:hilt-navigation-fragment:1.0.0"
-        private const val version = "2.5.1"
-        const val navigation = "androidx.navigation:navigation-ui-ktx:$version"
-        const val navigationFragment = "androidx.navigation:navigation-fragment-ktx:$version"
+        const val nav_version = "2.5.1"
+        const val navigation = "androidx.navigation:navigation-ui-ktx:$nav_version"
+        const val navigationFragment = "androidx.navigation:navigation-fragment-ktx:$nav_version"
         const val core = "androidx.core:core-ktx:1.8.0"
         const val appcompat = "androidx.appcompat:appcompat:1.5.0"
         const val material = "com.google.android.material:material:1.6.1"
@@ -29,7 +29,7 @@ object Deps {
         const val fragmentKTX = "androidx.fragment:fragment-ktx:1.5.0"
         const val security = "androidx.security:security-crypto-ktx:1.1.0-alpha03"
         const val paging = "androidx.paging:paging-runtime-ktx:3.1.1"
-        const val pagingWithoutAndroid ="androidx.paging:paging-common-ktx:3.1.1"
+        const val pagingWithoutAndroid = "androidx.paging:paging-common-ktx:3.1.1"
 
         object Compose {
             const val activity = "androidx.activity:activity-compose:1.5.1"

--- a/data/src/main/java/hous/release/data/datasource/TodoDataSource.kt
+++ b/data/src/main/java/hous/release/data/datasource/TodoDataSource.kt
@@ -39,4 +39,19 @@ class TodoDataSource @Inject constructor(
             name = toDoName
         )
     )
+
+    suspend fun getEditTodoContent(todoId: Int) = toDoService.getEditTodoContent(todoId = todoId)
+    suspend fun putEditToDo(
+        todoId: Int,
+        isPushNotification: Boolean,
+        updateTodoUsers: List<UpdateToDoUser>,
+        toDoName: String
+    ) = toDoService.putEditToDo(
+        todoId = todoId,
+        UpdateToDoUsersRequest(
+            isPushNotification = isPushNotification,
+            todoUsers = updateTodoUsers,
+            name = toDoName
+        )
+    )
 }

--- a/data/src/main/java/hous/release/data/entity/response/EditToDoContentResponse.kt
+++ b/data/src/main/java/hous/release/data/entity/response/EditToDoContentResponse.kt
@@ -1,0 +1,7 @@
+package hous.release.data.entity.response
+
+data class EditToDoContentResponse(
+    val isPushNotification: Boolean,
+    val name: String,
+    val todoUsers: List<TodoUserResponse>
+)

--- a/data/src/main/java/hous/release/data/entity/response/ToDoUsersResponse.kt
+++ b/data/src/main/java/hous/release/data/entity/response/ToDoUsersResponse.kt
@@ -1,20 +1,5 @@
 package hous.release.data.entity.response
 
-import hous.release.domain.entity.HomyType
-import hous.release.domain.entity.response.ToDoUser
-
 data class ToDoUsersResponse(
-    val users: List<ToDoUserResponse> = emptyList()
-) {
-    data class ToDoUserResponse(
-        val color: String = "GRAY",
-        val nickname: String = "",
-        val onboardingId: Int = 0
-    ) {
-        fun toToDoUser() = ToDoUser().copy(
-            homyType = HomyType.valueOf(color),
-            nickname = nickname,
-            onBoardingId = onboardingId
-        )
-    }
-}
+    val users: List<TodoUserResponse> = emptyList()
+)

--- a/data/src/main/java/hous/release/data/entity/response/TodoUserResponse.kt
+++ b/data/src/main/java/hous/release/data/entity/response/TodoUserResponse.kt
@@ -1,0 +1,38 @@
+package hous.release.data.entity.response
+
+import hous.release.domain.entity.HomyType
+import hous.release.domain.entity.response.ToDoUser
+
+data class TodoUserResponse(
+    val color: String = "GRAY",
+    val dayOfWeeks: List<String> = emptyList(),
+    val isSelected: Boolean = false,
+    val nickname: String = "",
+    val onboardingId: Int = -1
+) {
+    fun toTodoUser() = ToDoUser().copy(
+        homyType = HomyType.valueOf(color),
+        nickname = nickname,
+        isChecked = isSelected,
+        onBoardingId = onboardingId,
+        dayOfWeeks = transformDayOfWeeks(dayOfWeeks)
+    )
+
+    private fun transformDayOfWeeks(dayOfWeeks: List<String>): List<Boolean> {
+        val newDayOfWeeks = MutableList(7) { false }
+        dayOfWeeks.forEach { day -> newDayOfWeeks[requireNotNull(dayIndexMap[day])] = true }
+        return newDayOfWeeks
+    }
+
+    companion object {
+        private val dayIndexMap = hashMapOf(
+            "MONDAY" to 0,
+            "TUESDAY" to 1,
+            "WEDNESDAY" to 2,
+            "THURSDAY" to 3,
+            "FRIDAY" to 4,
+            "SATURDAY" to 5,
+            "SUNDAY" to 6
+        )
+    }
+}

--- a/data/src/main/java/hous/release/data/entity/response/TodoUserResponse.kt
+++ b/data/src/main/java/hous/release/data/entity/response/TodoUserResponse.kt
@@ -4,13 +4,13 @@ import hous.release.domain.entity.HomyType
 import hous.release.domain.entity.response.ToDoUser
 
 data class TodoUserResponse(
-    val color: String = "GRAY",
+    val color: String = NO_COLOR,
     val dayOfWeeks: List<String> = emptyList(),
     val isSelected: Boolean = false,
     val nickname: String = "",
-    val onboardingId: Int = -1
+    val onboardingId: Int = NO_ID
 ) {
-    fun toTodoUser() = ToDoUser().copy(
+    fun toTodoUser() = ToDoUser(
         homyType = HomyType.valueOf(color),
         nickname = nickname,
         isChecked = isSelected,
@@ -25,6 +25,8 @@ data class TodoUserResponse(
     }
 
     companion object {
+        private const val NO_COLOR = "GRAY"
+        private const val NO_ID = -1
         private val dayIndexMap = hashMapOf(
             "MONDAY" to 0,
             "TUESDAY" to 1,

--- a/data/src/main/java/hous/release/data/service/TodoService.kt
+++ b/data/src/main/java/hous/release/data/service/TodoService.kt
@@ -3,6 +3,7 @@ package hous.release.data.service
 import hous.release.data.entity.request.ToDoCheckRequest
 import hous.release.data.entity.request.UpdateToDoUsersRequest
 import hous.release.data.entity.response.BaseResponse
+import hous.release.data.entity.response.EditToDoContentResponse
 import hous.release.data.entity.response.MemberTodoResponse
 import hous.release.data.entity.response.NoDataResponse
 import hous.release.data.entity.response.ToDoMainResponse
@@ -12,6 +13,7 @@ import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.PUT
 import retrofit2.http.Path
 
 interface TodoService {
@@ -43,4 +45,13 @@ interface TodoService {
 
     @POST("/v1/todo")
     suspend fun postAddTodo(@Body updateToDoUser: UpdateToDoUsersRequest): NoDataResponse
+
+    @GET("/v1/todo/{todoId}")
+    suspend fun getEditTodoContent(@Path("todoId") todoId: Int): BaseResponse<EditToDoContentResponse>
+
+    @PUT("/v1/todo/{todoId}")
+    suspend fun putEditToDo(
+        @Path("todoId") todoId: Int,
+        @Body updateToDoUsersRequest: UpdateToDoUsersRequest
+    ): NoDataResponse
 }

--- a/domain/src/main/java/hous/release/domain/entity/response/ToDoContent.kt
+++ b/domain/src/main/java/hous/release/domain/entity/response/ToDoContent.kt
@@ -1,0 +1,7 @@
+package hous.release.domain.entity.response
+
+data class ToDoContent(
+    val isPushNotification: Boolean,
+    val name: String,
+    val todoUsers: List<ToDoUser>
+)

--- a/domain/src/main/java/hous/release/domain/repository/TodoRepository.kt
+++ b/domain/src/main/java/hous/release/domain/repository/TodoRepository.kt
@@ -3,6 +3,7 @@ package hous.release.domain.repository
 import hous.release.domain.entity.ApiResult
 import hous.release.domain.entity.TodoDetail
 import hous.release.domain.entity.response.MemberTodoContent
+import hous.release.domain.entity.response.ToDoContent
 import hous.release.domain.entity.response.ToDoUser
 import hous.release.domain.entity.response.TodoMain
 import kotlinx.coroutines.flow.Flow
@@ -16,6 +17,14 @@ interface TodoRepository {
     suspend fun deleteTodo(todoId: Int)
     fun getToDoUsers(): Flow<ApiResult<List<ToDoUser>>>
     fun postAddToDo(
+        isPushNotification: Boolean,
+        todoUsers: List<ToDoUser>,
+        toDoName: String
+    ): Flow<ApiResult<String>>
+
+    fun getEditTodoContent(todoId: Int): Flow<ApiResult<ToDoContent>>
+    fun putEditToDo(
+        todoId: Int,
         isPushNotification: Boolean,
         todoUsers: List<ToDoUser>,
         toDoName: String

--- a/domain/src/main/java/hous/release/domain/usecase/GetEditTodoContentUseCase.kt
+++ b/domain/src/main/java/hous/release/domain/usecase/GetEditTodoContentUseCase.kt
@@ -1,0 +1,8 @@
+package hous.release.domain.usecase
+
+import hous.release.domain.repository.TodoRepository
+import javax.inject.Inject
+
+class GetEditTodoContentUseCase @Inject constructor(private val todoRepository: TodoRepository) {
+    operator fun invoke(todoId: Int) = todoRepository.getEditTodoContent(todoId = todoId)
+}

--- a/domain/src/main/java/hous/release/domain/usecase/PutEditToDoUseCase.kt
+++ b/domain/src/main/java/hous/release/domain/usecase/PutEditToDoUseCase.kt
@@ -1,0 +1,14 @@
+package hous.release.domain.usecase
+
+import hous.release.domain.entity.response.ToDoUser
+import hous.release.domain.repository.TodoRepository
+import javax.inject.Inject
+
+class PutEditToDoUseCase @Inject constructor(private val todoRepository: TodoRepository) {
+    operator fun invoke(
+        todoId: Int,
+        isPushNotification: Boolean,
+        todoUsers: List<ToDoUser>,
+        toDoName: String
+    ) = todoRepository.putEditToDo(todoId, isPushNotification, todoUsers, toDoName)
+}


### PR DESCRIPTION
## 관련 이슈
- closed #110 
## 작업영상 

https://user-images.githubusercontent.com/87055456/200102477-3d0c84f3-b606-49a6-b9e3-d2c14a030455.mp4    

## 작업한 내용
- todo 수정 뷰 구현
- todo 수정 기능 구현
- todo 수정 서버 연동
- bottomSheet에서 EditFragment로 `todoId`, `navigate` 패싱
## PR 포인트
- 열심히했습니다!!

