### PR TITLE
#145 [feat] 로그인 시 SplashState 초기화 해주기

### DIFF
--- a/app/src/main/java/hous/release/android/di/RefreshRetrofitModule.kt
+++ b/app/src/main/java/hous/release/android/di/RefreshRetrofitModule.kt
@@ -23,6 +23,7 @@ object RefreshRetrofitModule {
     private const val HEADER_OS_TYPE = "HousOsType"
     private const val HEADER_VERSION = "HousVersion"
     private const val OS_TYPE = "AOS"
+    private const val BEARER = "Bearer "
 
     @Qualifier
     @Retention(AnnotationRetention.BINARY)
@@ -41,7 +42,7 @@ object RefreshRetrofitModule {
                     .newBuilder()
                     .addHeader(
                         HEADER_AUTHORIZATION,
-                        localPrefTokenDataSource.accessToken
+                        BEARER + localPrefTokenDataSource.accessToken
                     )
                     .addHeader(HEADER_OS_TYPE, OS_TYPE)
                     .addHeader(HEADER_VERSION, BuildConfig.VERSION_NAME)

--- a/app/src/main/java/hous/release/android/di/RetrofitModule.kt
+++ b/app/src/main/java/hous/release/android/di/RetrofitModule.kt
@@ -36,6 +36,7 @@ object RetrofitModule {
     private const val HEADER_OS_TYPE = "HousOsType"
     private const val HEADER_VERSION = "HousVersion"
     private const val OS_TYPE = "AOS"
+    private const val BEARER = "Bearer "
 
     @Qualifier
     @Retention(AnnotationRetention.BINARY)
@@ -57,7 +58,7 @@ object RetrofitModule {
                     .newBuilder()
                     .addHeader(
                         HEADER_AUTHORIZATION,
-                        localPrefTokenDataSource.accessToken
+                        BEARER + localPrefTokenDataSource.accessToken
                     )
                     .addHeader(HEADER_OS_TYPE, OS_TYPE)
                     .addHeader(HEADER_VERSION, BuildConfig.VERSION_NAME)
@@ -73,7 +74,7 @@ object RetrofitModule {
                                         .newBuilder()
                                         .addHeader(
                                             HEADER_AUTHORIZATION,
-                                            localPrefTokenDataSource.accessToken
+                                            BEARER + localPrefTokenDataSource.accessToken
                                         )
                                         .addHeader(HEADER_OS_TYPE, OS_TYPE)
                                         .addHeader(HEADER_VERSION, BuildConfig.VERSION_NAME)

--- a/app/src/main/java/hous/release/android/presentation/login/LoginViewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/login/LoginViewModel.kt
@@ -9,11 +9,13 @@ import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.common.model.AuthErrorCause
 import dagger.hilt.android.lifecycle.HiltViewModel
 import hous.release.android.util.extension.Event
+import hous.release.domain.entity.SplashState
 import hous.release.domain.usecase.GetFcmTokenUseCase
 import hous.release.domain.usecase.InitHousTokenUseCase
 import hous.release.domain.usecase.InitTokenUseCase
 import hous.release.domain.usecase.PostForceLoginUseCase
 import hous.release.domain.usecase.PostLoginUseCase
+import hous.release.domain.usecase.SetSplashStateUseCase
 import kotlinx.coroutines.launch
 import retrofit2.HttpException
 import timber.log.Timber
@@ -25,7 +27,8 @@ class LoginViewModel @Inject constructor(
     private val initTokenUseCase: InitTokenUseCase,
     private val initHousTokenUseCase: InitHousTokenUseCase,
     private val getFcmTokenUseCase: GetFcmTokenUseCase,
-    private val postForceLoginUseCase: PostForceLoginUseCase
+    private val postForceLoginUseCase: PostForceLoginUseCase,
+    private val setSplashStateUseCase: SetSplashStateUseCase
 ) : ViewModel() {
     private val kakaoToken = MutableLiveData<String>()
 
@@ -111,6 +114,10 @@ class LoginViewModel @Inject constructor(
                     token = response.token
                 )
                 _isJoiningRoom.value = response.isJoiningRoom
+                setSplashStateUseCase(
+                    if (response.isJoiningRoom) SplashState.MAIN
+                    else SplashState.ENTER_ROOM
+                )
             }.onFailure { throwable ->
                 if (throwable is HttpException) {
                     when (throwable.code()) {
@@ -150,6 +157,10 @@ class LoginViewModel @Inject constructor(
                 )
                 initHousTokenUseCase(
                     token = response.token
+                )
+                setSplashStateUseCase(
+                    if (response.isJoiningRoom) SplashState.MAIN
+                    else SplashState.ENTER_ROOM
                 )
             }.onFailure { throwable ->
                 Timber.e(throwable.message)

--- a/data/src/main/java/hous/release/data/datasource/LocalPrefTokenDataSource.kt
+++ b/data/src/main/java/hous/release/data/datasource/LocalPrefTokenDataSource.kt
@@ -8,11 +8,11 @@ class LocalPrefTokenDataSource @Inject constructor(
     private val prefs: SharedPreferences
 ) {
     var accessToken: String
-        set(value) = prefs.edit { putString(ACCESS_TOKEN, BEARER + value) }
+        set(value) = prefs.edit { putString(ACCESS_TOKEN, value) }
         get() = prefs.getString(ACCESS_TOKEN, "") ?: ""
 
     var refreshToken: String
-        set(value) = prefs.edit { putString(REFRESH_TOKEN, BEARER + value) }
+        set(value) = prefs.edit { putString(REFRESH_TOKEN, value) }
         get() = prefs.getString(REFRESH_TOKEN, "") ?: ""
 
     var fcmToken: String
@@ -28,7 +28,6 @@ class LocalPrefTokenDataSource @Inject constructor(
         get() = prefs.getString(TOKEN, "") ?: ""
 
     companion object {
-        const val BEARER = "Bearer "
         const val ACCESS_TOKEN = "access_token"
         const val REFRESH_TOKEN = "refresh_token"
         private const val FCM_TOKEN = "fcm_token"

--- a/data/src/main/java/hous/release/data/datasource/LocalPrefTokenDataSource.kt
+++ b/data/src/main/java/hous/release/data/datasource/LocalPrefTokenDataSource.kt
@@ -8,11 +8,11 @@ class LocalPrefTokenDataSource @Inject constructor(
     private val prefs: SharedPreferences
 ) {
     var accessToken: String
-        set(value) = prefs.edit { putString(ACCESS_TOKEN, "Bearer $value") }
+        set(value) = prefs.edit { putString(ACCESS_TOKEN, BEARER + value) }
         get() = prefs.getString(ACCESS_TOKEN, "") ?: ""
 
     var refreshToken: String
-        set(value) = prefs.edit { putString(REFRESH_TOKEN, "Bearer $value") }
+        set(value) = prefs.edit { putString(REFRESH_TOKEN, BEARER + value) }
         get() = prefs.getString(REFRESH_TOKEN, "") ?: ""
 
     var fcmToken: String
@@ -28,6 +28,7 @@ class LocalPrefTokenDataSource @Inject constructor(
         get() = prefs.getString(TOKEN, "") ?: ""
 
     companion object {
+        const val BEARER = "Bearer "
         const val ACCESS_TOKEN = "access_token"
         const val REFRESH_TOKEN = "refresh_token"
         private const val FCM_TOKEN = "fcm_token"

--- a/data/src/main/java/hous/release/data/repository/RefreshRepositoryImpl.kt
+++ b/data/src/main/java/hous/release/data/repository/RefreshRepositoryImpl.kt
@@ -1,7 +1,6 @@
 package hous.release.data.repository
 
 import hous.release.data.datasource.LocalPrefTokenDataSource
-import hous.release.data.datasource.LocalPrefTokenDataSource.Companion.BEARER
 import hous.release.data.datasource.RefreshDataSource
 import hous.release.data.entity.TokenEntity
 import hous.release.domain.entity.response.RefreshHousToken
@@ -16,10 +15,8 @@ class RefreshRepositoryImpl @Inject constructor(
         kotlin.runCatching {
             refreshDataSource.refreshHousToken(
                 TokenEntity(
-                    accessToken =
-                    localPrefTokenDataSource.accessToken.removePrefix(BEARER),
-                    refreshToken =
-                    localPrefTokenDataSource.refreshToken.removePrefix(BEARER),
+                    accessToken = localPrefTokenDataSource.accessToken,
+                    refreshToken = localPrefTokenDataSource.refreshToken
                 )
             )
         }.map { response ->

--- a/data/src/main/java/hous/release/data/repository/RefreshRepositoryImpl.kt
+++ b/data/src/main/java/hous/release/data/repository/RefreshRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package hous.release.data.repository
 
 import hous.release.data.datasource.LocalPrefTokenDataSource
+import hous.release.data.datasource.LocalPrefTokenDataSource.Companion.BEARER
 import hous.release.data.datasource.RefreshDataSource
 import hous.release.data.entity.TokenEntity
 import hous.release.domain.entity.response.RefreshHousToken
@@ -15,8 +16,10 @@ class RefreshRepositoryImpl @Inject constructor(
         kotlin.runCatching {
             refreshDataSource.refreshHousToken(
                 TokenEntity(
-                    accessToken = localPrefTokenDataSource.accessToken,
-                    refreshToken = localPrefTokenDataSource.refreshToken
+                    accessToken =
+                    localPrefTokenDataSource.accessToken.removePrefix(BEARER),
+                    refreshToken =
+                    localPrefTokenDataSource.refreshToken.removePrefix(BEARER),
                 )
             )
         }.map { response ->


### PR DESCRIPTION
## 관련 이슈
- closed #145

## 작업한 내용
- LoginViewModel : 로그인(강제로그인 포함) 시 SplashState 초기화 해주기 (@KWY0218  이부분 추가했습니다!)
- 토큰 갱신 시에는 Bearer Prefix 제거해주기
- 토큰 저장 시에는 그대로 저장하고 헤더에 담을 때만 Bearer Prefix 붙여주도록 리팩토링

## PR 포인트
- 자동로그인이 안되는 것을 확인하고 로그인, 강제로그인 시의 response에 담겨오는 isJoingRoom값에 따라 SplashState를 초기화해줬습니다. 
  - isJoiningRoom == true -> SplashState.MAIN
  - isJoiningRoom == false -> SplashState.ENTER_ROOM

- 로그인, 회원가입, 토큰 갱신 시 토큰 저장 방식을 수정했습니다. 이번 pr이 머지되면 캐시,데이터 삭제 후 재로그인이나 재회원가입 해주시면 됩니다!
