### PR TITLE
#154 [feat/fix] 방참여 중 이탈 시 이슈 및 Hous- 탭 QA 수정사항 반영

### DIFF
--- a/app/src/main/java/hous/release/android/di/RetrofitModule.kt
+++ b/app/src/main/java/hous/release/android/di/RetrofitModule.kt
@@ -12,7 +12,7 @@ import dagger.hilt.components.SingletonComponent
 import hous.release.android.BuildConfig
 import hous.release.android.R
 import hous.release.android.presentation.login.LoginActivity
-import hous.release.android.util.showToast
+import hous.release.android.util.ToastMessageUtil
 import hous.release.data.datasource.LocalPrefTokenDataSource
 import hous.release.data.repository.RefreshRepositoryImpl.Companion.EXPIRED_REFRESH_TOKEN
 import hous.release.data.repository.RefreshRepositoryImpl.Companion.EXPIRED_TOKEN
@@ -90,7 +90,10 @@ object RetrofitModule {
                                                 clear()
                                                 commit()
                                             }
-                                            context.showToast(context.getString(R.string.refresh_error))
+                                            ToastMessageUtil.showToast(
+                                                context,
+                                                context.getString(R.string.refresh_error)
+                                            )
                                             context.startActivity(
                                                 Intent(context, LoginActivity::class.java).apply {
                                                     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)

--- a/app/src/main/java/hous/release/android/presentation/enter_room/enter_room_code/EnterRoomCodeFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/enter_room/enter_room_code/EnterRoomCodeFragment.kt
@@ -8,9 +8,9 @@ import dagger.hilt.android.AndroidEntryPoint
 import hous.release.android.R
 import hous.release.android.databinding.FragmentEnterRoomCodeBinding
 import hous.release.android.util.KeyBoardUtil
+import hous.release.android.util.ToastMessageUtil
 import hous.release.android.util.binding.BindingFragment
 import hous.release.android.util.extension.repeatOnStarted
-import hous.release.android.util.showToast
 
 @AndroidEntryPoint
 class EnterRoomCodeFragment :
@@ -55,7 +55,10 @@ class EnterRoomCodeFragment :
         repeatOnStarted {
             viewModel.isFullCapacity.collect { isFull ->
                 if (isFull) {
-                    requireContext().showToast(getString(R.string.enter_room_code_full_capacity))
+                    ToastMessageUtil.showToast(
+                        requireContext(),
+                        getString(R.string.enter_room_code_full_capacity)
+                    )
                 }
             }
         }

--- a/app/src/main/java/hous/release/android/presentation/enter_room/enter_room_code/EnterRoomCodeViewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/enter_room/enter_room_code/EnterRoomCodeViewModel.kt
@@ -46,7 +46,6 @@ class EnterRoomCodeViewModel @Inject constructor(
             enterRoomRepository.getEnterRoomCode(roomCode.value)
                 .onSuccess { response ->
                     _roomInfo.value = response
-                    setSplashStateUseCase(SplashState.MAIN)
                     _isSuccessGetRoom.emit(true)
                 }
                 .onFailure {
@@ -59,6 +58,7 @@ class EnterRoomCodeViewModel @Inject constructor(
         viewModelScope.launch {
             enterRoomRepository.postEnterRoomId(roomInfo.value.roomId.toString())
                 .onSuccess {
+                    setSplashStateUseCase(SplashState.MAIN)
                     _isSuccessEnterRoom.emit(true)
                 }
                 .onFailure { throwable ->

--- a/app/src/main/java/hous/release/android/presentation/hous/EditHousNameActivity.kt
+++ b/app/src/main/java/hous/release/android/presentation/hous/EditHousNameActivity.kt
@@ -38,10 +38,16 @@ class EditHousNameActivity :
     }
 
     private fun initBackBtnClickListener() {
-        binding.btnEditHousNameBack.setOnClickListener { showWarningDialog() }
+        binding.btnEditHousNameBack.setOnClickListener { exitEdit() }
 
-        onBackPressedDispatcher.addCallback {
+        onBackPressedDispatcher.addCallback { exitEdit() }
+    }
+
+    private fun exitEdit() {
+        if (viewModel.getIsEdited()) {
             showWarningDialog()
+        } else {
+            finish()
         }
     }
 

--- a/app/src/main/java/hous/release/android/presentation/hous/EditHousNameViewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/hous/EditHousNameViewModel.kt
@@ -27,6 +27,8 @@ class EditHousNameViewModel @Inject constructor(
         roomName.value = originalRoomName
     }
 
+    fun getIsEdited(): Boolean = originalRoomName != roomName.value
+
     fun putHousName() {
         viewModelScope.launch {
             housRepository.putHousName(roomName.value)

--- a/app/src/main/java/hous/release/android/presentation/hous/HousFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/hous/HousFragment.kt
@@ -14,9 +14,9 @@ import hous.release.android.presentation.hous.adapter.HomiesAdapter
 import hous.release.android.presentation.main.MainActivity
 import hous.release.android.presentation.our_rules.OurRulesActivity
 import hous.release.android.presentation.profile.homie.HomieProfileActivity
+import hous.release.android.util.ToastMessageUtil
 import hous.release.android.util.binding.BindingFragment
 import hous.release.android.util.extension.repeatOnStarted
-import hous.release.android.util.showToast
 import hous.release.domain.entity.HomyType
 import hous.release.domain.entity.response.Homy
 import timber.log.Timber
@@ -69,7 +69,10 @@ class HousFragment : BindingFragment<FragmentHousBinding>(R.layout.fragment_hous
             val clipCode =
                 ClipData.newPlainText(ROOM_CODE, viewModel.hous.value.roomCode)
             clipboard.setPrimaryClip(clipCode)
-            requireContext().showToast(getString(R.string.hous_toast_copy))
+            ToastMessageUtil.showToast(
+                requireContext(),
+                getString(R.string.hous_toast_copy)
+            )
         }
     }
 

--- a/app/src/main/java/hous/release/android/presentation/hous/HousFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/hous/HousFragment.kt
@@ -85,6 +85,9 @@ class HousFragment : BindingFragment<FragmentHousBinding>(R.layout.fragment_hous
         binding.btnHousOurRules.setOnClickListener {
             startActivity(Intent(requireContext(), OurRulesActivity::class.java))
         }
+        binding.layoutHousOurRules.setOnClickListener {
+            startActivity(Intent(requireContext(), OurRulesActivity::class.java))
+        }
     }
 
     private fun initMoveToToDoClickListener() {

--- a/app/src/main/java/hous/release/android/presentation/hous/HousFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/hous/HousFragment.kt
@@ -45,7 +45,12 @@ class HousFragment : BindingFragment<FragmentHousBinding>(R.layout.fragment_hous
         val currentId = homy.homieId
         Timber.e("${homy.homieId}")
         when (HomyType.valueOf(homy.color)) {
-            HomyType.GRAY -> return
+            HomyType.GRAY -> {
+                ToastMessageUtil.showToast(
+                    requireContext(),
+                    getString(R.string.hous_not_tested_yet)
+                )
+            }
             else -> {
                 val toHomieProfile = Intent(requireActivity(), HomieProfileActivity::class.java)
                 toHomieProfile.putExtra(HOMIE_ID, currentId)

--- a/app/src/main/java/hous/release/android/presentation/login/LoginActivity.kt
+++ b/app/src/main/java/hous/release/android/presentation/login/LoginActivity.kt
@@ -9,12 +9,12 @@ import hous.release.android.R
 import hous.release.android.databinding.ActivityLoginBinding
 import hous.release.android.presentation.enter_room.EnterRoomActivity
 import hous.release.android.presentation.main.MainActivity
+import hous.release.android.util.ToastMessageUtil
 import hous.release.android.util.binding.BindingActivity
 import hous.release.android.util.dialog.ConfirmClickListener
 import hous.release.android.util.dialog.WarningDialogFragment
 import hous.release.android.util.dialog.WarningType
 import hous.release.android.util.extension.EventObserver
-import hous.release.android.util.showToast
 import hous.release.data.service.KakaoLoginService
 import timber.log.Timber
 import javax.inject.Inject
@@ -41,7 +41,7 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
     private fun initIsUserObserve() {
         loginViewModel.isJoiningRoom.observe(this) {
             if (loginViewModel.isJoiningRoom.value == true) {
-                showToast(getString(R.string.login_toast))
+                ToastMessageUtil.showToast(this@LoginActivity, getString(R.string.login_toast))
                 val toMain = Intent(this, MainActivity::class.java)
                 startActivity(toMain)
                 finishAffinity()
@@ -67,7 +67,10 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
         onBackPressedDispatcher.addCallback {
             if (System.currentTimeMillis() - onBackPressedTime >= WAITING_DEADLINE) {
                 onBackPressedTime = System.currentTimeMillis()
-                showToast(getString(R.string.finish_app_toast_msg))
+                ToastMessageUtil.showToast(
+                    this@LoginActivity,
+                    getString(R.string.finish_app_toast_msg)
+                )
             } else {
                 finishAffinity()
                 System.runFinalization()

--- a/app/src/main/java/hous/release/android/presentation/login/UserInputActivity.kt
+++ b/app/src/main/java/hous/release/android/presentation/login/UserInputActivity.kt
@@ -8,11 +8,11 @@ import dagger.hilt.android.AndroidEntryPoint
 import hous.release.android.R
 import hous.release.android.databinding.ActivityUserInputBinding
 import hous.release.android.presentation.enter_room.EnterRoomActivity
+import hous.release.android.util.ToastMessageUtil
 import hous.release.android.util.binding.BindingActivity
 import hous.release.android.util.dialog.DatePickerClickListener
 import hous.release.android.util.dialog.DatePickerDialog
 import hous.release.android.util.dialog.WarningDialogFragment.Companion.CONFIRM_ACTION
-import hous.release.android.util.showToast
 import kotlin.system.exitProcess
 
 @AndroidEntryPoint
@@ -36,7 +36,10 @@ class UserInputActivity : BindingActivity<ActivityUserInputBinding>(R.layout.act
                 override fun handleOnBackPressed() {
                     if (System.currentTimeMillis() - onBackPressedTime >= WAITING_DEADLINE) {
                         onBackPressedTime = System.currentTimeMillis()
-                        showToast(getString(R.string.finish_app_toast_msg))
+                        ToastMessageUtil.showToast(
+                            this@UserInputActivity,
+                            getString(R.string.finish_app_toast_msg)
+                        )
                     } else {
                         finishAffinity()
                         System.runFinalization()

--- a/app/src/main/java/hous/release/android/presentation/main/MainActivity.kt
+++ b/app/src/main/java/hous/release/android/presentation/main/MainActivity.kt
@@ -9,8 +9,8 @@ import androidx.navigation.ui.setupWithNavController
 import dagger.hilt.android.AndroidEntryPoint
 import hous.release.android.R
 import hous.release.android.databinding.ActivityMainBinding
+import hous.release.android.util.ToastMessageUtil
 import hous.release.android.util.binding.BindingActivity
-import hous.release.android.util.showToast
 import timber.log.Timber
 import kotlin.system.exitProcess
 
@@ -43,7 +43,10 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
                     val gap = curTime - onBackPressedTime
                     if (gap > WAITING_DEADLINE) {
                         onBackPressedTime = curTime
-                        showToast(getString(R.string.finish_app_toast_msg))
+                        ToastMessageUtil.showToast(
+                            this@MainActivity,
+                            getString(R.string.finish_app_toast_msg)
+                        )
                         return@addCallback
                     }
                     finishAffinity()

--- a/app/src/main/java/hous/release/android/presentation/out_room/OutRoomActivity.kt
+++ b/app/src/main/java/hous/release/android/presentation/out_room/OutRoomActivity.kt
@@ -8,9 +8,9 @@ import hous.release.android.R
 import hous.release.android.databinding.ActivityOutRoomBinding
 import hous.release.android.presentation.enter_room.EnterRoomActivity
 import hous.release.android.presentation.out_room.adapter.MyToDoAdapter
+import hous.release.android.util.ToastMessageUtil
 import hous.release.android.util.binding.BindingActivity
 import hous.release.android.util.extension.repeatOnStarted
-import hous.release.android.util.showToast
 
 @AndroidEntryPoint
 class OutRoomActivity : BindingActivity<ActivityOutRoomBinding>(R.layout.activity_out_room) {
@@ -47,7 +47,10 @@ class OutRoomActivity : BindingActivity<ActivityOutRoomBinding>(R.layout.activit
         repeatOnStarted {
             viewModel.isSuccessDeleteRoom.collect { isSuccess ->
                 if (isSuccess) {
-                    showToast(getString(R.string.out_room_toast))
+                    ToastMessageUtil.showToast(
+                        this@OutRoomActivity,
+                        getString(R.string.out_room_toast)
+                    )
                     startActivity(
                         Intent(this, EnterRoomActivity::class.java).apply {
                             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)

--- a/app/src/main/java/hous/release/android/presentation/settings/SettingsActivity.kt
+++ b/app/src/main/java/hous/release/android/presentation/settings/SettingsActivity.kt
@@ -12,12 +12,12 @@ import hous.release.android.databinding.ActivitySettingsBinding
 import hous.release.android.presentation.login.LoginActivity
 import hous.release.android.presentation.out_room.OutRoomActivity
 import hous.release.android.presentation.withdraw.WithdrawActivity
+import hous.release.android.util.ToastMessageUtil
 import hous.release.android.util.binding.BindingActivity
 import hous.release.android.util.dialog.ConfirmClickListener
 import hous.release.android.util.dialog.WarningDialogFragment
 import hous.release.android.util.dialog.WarningType
 import hous.release.android.util.extension.repeatOnStarted
-import hous.release.android.util.showToast
 
 @AndroidEntryPoint
 class SettingsActivity : BindingActivity<ActivitySettingsBinding>(R.layout.activity_settings) {
@@ -103,7 +103,10 @@ class SettingsActivity : BindingActivity<ActivitySettingsBinding>(R.layout.activ
         repeatOnStarted {
             viewModel.isSuccessLogout.collect { isSuccess ->
                 if (isSuccess) {
-                    showToast(getString(R.string.settings_logout_toast))
+                    ToastMessageUtil.showToast(
+                        this@SettingsActivity,
+                        getString(R.string.settings_logout_toast)
+                    )
                     startActivity(
                         Intent(this, LoginActivity::class.java).apply {
                             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)

--- a/app/src/main/java/hous/release/android/presentation/tutorial/TutorialActivity.kt
+++ b/app/src/main/java/hous/release/android/presentation/tutorial/TutorialActivity.kt
@@ -11,8 +11,8 @@ import hous.release.android.R
 import hous.release.android.databinding.ActivityTutorialBinding
 import hous.release.android.presentation.login.LoginActivity
 import hous.release.android.presentation.tutorial.adapter.TutorialAdapter
+import hous.release.android.util.ToastMessageUtil
 import hous.release.android.util.binding.BindingActivity
-import hous.release.android.util.showToast
 import hous.release.domain.entity.TutorialEntity
 import kotlin.system.exitProcess
 
@@ -35,7 +35,10 @@ class TutorialActivity : BindingActivity<ActivityTutorialBinding>(R.layout.activ
         onBackPressedDispatcher.addCallback {
             if (System.currentTimeMillis() - onBackPressedTime >= WAITING_DEADLINE) {
                 onBackPressedTime = System.currentTimeMillis()
-                showToast(getString(R.string.finish_app_toast_msg))
+                ToastMessageUtil.showToast(
+                    this@TutorialActivity,
+                    getString(R.string.finish_app_toast_msg)
+                )
             } else {
                 finishAffinity()
                 System.runFinalization()

--- a/app/src/main/java/hous/release/android/presentation/withdraw/WithdrawActivity.kt
+++ b/app/src/main/java/hous/release/android/presentation/withdraw/WithdrawActivity.kt
@@ -10,9 +10,9 @@ import dagger.hilt.android.AndroidEntryPoint
 import hous.release.android.R
 import hous.release.android.databinding.ActivityWithdrawBinding
 import hous.release.android.presentation.login.LoginActivity
+import hous.release.android.util.ToastMessageUtil
 import hous.release.android.util.binding.BindingActivity
 import hous.release.android.util.extension.repeatOnStarted
-import hous.release.android.util.showToast
 import hous.release.domain.entity.FeedbackType
 
 @AndroidEntryPoint
@@ -36,7 +36,10 @@ class WithdrawActivity :
         repeatOnStarted {
             viewModel.isSuccessWithdraw.collect { isSuccess ->
                 if (isSuccess) {
-                    showToast(getString(R.string.withdraw_toast))
+                    ToastMessageUtil.showToast(
+                        this@WithdrawActivity,
+                        getString(R.string.withdraw_toast)
+                    )
                     startActivity(
                         Intent(this, LoginActivity::class.java).apply {
                             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)

--- a/app/src/main/java/hous/release/android/util/ToastMessageUtil.kt
+++ b/app/src/main/java/hous/release/android/util/ToastMessageUtil.kt
@@ -2,7 +2,17 @@ package hous.release.android.util
 
 import android.content.Context
 import android.widget.Toast
+import timber.log.Timber
 
-fun Context.showToast(msg: String) {
-    Toast.makeText(this, msg, Toast.LENGTH_SHORT).show()
+object ToastMessageUtil {
+    private var toast: Toast? = null
+
+    fun showToast(context: Context, msg: String) {
+        if (toast == null) {
+            Timber.d("toast null")
+        }
+        toast?.cancel()
+        toast = Toast.makeText(context, msg, Toast.LENGTH_SHORT)
+        requireNotNull(toast).show()
+    }
 }

--- a/app/src/main/java/hous/release/android/util/ToastMessageUtil.kt
+++ b/app/src/main/java/hous/release/android/util/ToastMessageUtil.kt
@@ -2,15 +2,11 @@ package hous.release.android.util
 
 import android.content.Context
 import android.widget.Toast
-import timber.log.Timber
 
 object ToastMessageUtil {
     private var toast: Toast? = null
 
     fun showToast(context: Context, msg: String) {
-        if (toast == null) {
-            Timber.d("toast null")
-        }
         toast?.cancel()
         toast = Toast.makeText(context, msg, Toast.LENGTH_SHORT)
         requireNotNull(toast).show()

--- a/app/src/main/res/layout/fragment_enter_room_code.xml
+++ b/app/src/main/res/layout/fragment_enter_room_code.xml
@@ -89,7 +89,7 @@
             app:layout_constraintTop_toBottomOf="@id/et_enter_room_code_name" />
 
         <com.google.android.material.button.MaterialButton
-            android:id="@+id/btn_create_room_done"
+            android:id="@+id/btn_enter_room_code_done"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="16dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -358,7 +358,7 @@
     <string name="withdraw_comment_hint">의견 남기기</string>
     <string name="withdraw_comment_count">%d/200</string>
     <string name="withdraw_check_desc">탈퇴하겠습니다.</string>
-    <string name="withdraw_done">방 탈퇴하기</string>
+    <string name="withdraw_done">회원 탈퇴하기</string>
     <string name="withdraw_spinner_img_desc">피드백 스피너 이미지</string>
     <string name="withdraw_toast">탈퇴되었습니다.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,6 +151,7 @@
     <string name="hous_empty_our_rules">아직 우리 집 Rules가 없어요!</string>
     <string name="hous_empty_our_rules_add">다른 Rule도 추가해보세요!</string>
     <string name="hous_toast_copy">참여코드가 복사되었습니다.</string>
+    <string name="hous_not_tested_yet">아직 성향 테스트를 하지 않은 호미예요!</string>
 
     <!-- EditHousName -->
     <string name="edit_hous_name_back_img_desc">back button</string>


### PR DESCRIPTION
## 관련 이슈
- closed #154

## 작업한 내용

-  방 코드 검색 시 state바꿔주는 부분을 -> 방 참여 팝업의 '참여하기' 버튼 누를 시 state바꿔주도록 수정
-  토스트 중복 막도록 코드 수정
-  Hous탭 - Homies - 호미카드(회색) 클릭 시 -> "아직 성향 테스트를 하지 않은 호미예요!" 토스트 노출
-  Hous탭 - 우리집 별명 수정 - 수정 내역 O = 수정 이탈 팝업 / 수정 내역 X = Home main view로 이동
-  Hous탭 - Rules 파란 영역 클릭 시에도 화면 이동하도록 구현
-  회원 탈퇴하기 워딩 수정

## PR 포인트
- 없습니다~! 끝에 다와간다!!! 화이팅!
