### PR TITLE
#153 [fix] fix to do update

### DIFF
--- a/app/src/main/java/hous/release/android/presentation/our_rules/add_rule/OurRuleAddErrorDialogFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/our_rules/add_rule/OurRuleAddErrorDialogFragment.kt
@@ -36,6 +36,5 @@ class OurRuleAddErrorDialogFragment : DialogFragment() {
         binding.tvOurRuleAddErrorOkBtn.setOnClickListener {
             dismiss()
         }
-        requireContext()
     }
 }

--- a/app/src/main/java/hous/release/android/presentation/todo/add/AddToDoFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/add/AddToDoFragment.kt
@@ -3,7 +3,6 @@ package hous.release.android.presentation.todo.add
 import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.View
-import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.addCallback
 import androidx.fragment.app.viewModels
@@ -14,6 +13,7 @@ import hous.release.android.databinding.FragmentAddToDoBinding
 import hous.release.android.presentation.todo.detail.TodoLimitDialog
 import hous.release.android.presentation.todo.edit.UpdateToDoEvent
 import hous.release.android.util.KeyBoardUtil
+import hous.release.android.util.ToastMessageUtil
 import hous.release.android.util.binding.BindingFragment
 import hous.release.android.util.dialog.ConfirmClickListener
 import hous.release.android.util.dialog.LoadingDialogFragment
@@ -96,9 +96,10 @@ class AddToDoFragment : BindingFragment<FragmentAddToDoBinding>(R.layout.fragmen
                         TodoLimitDialog().show(childFragmentManager, TodoLimitDialog.TAG)
                     }
                     UpdateToDoEvent.Duplicate -> {
-                        // TODO 확장함수 쓰기
-                        Toast.makeText(requireContext(), requireContext().getString(R.string.to_do_duplicate_toast_msg), Toast.LENGTH_SHORT)
-                            .show()
+                        ToastMessageUtil.showToast(
+                            requireContext(),
+                            getString(R.string.to_do_duplicate_toast_msg)
+                        )
                     }
                 }
             }

--- a/app/src/main/java/hous/release/android/presentation/todo/add/AddToDoVIewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/add/AddToDoVIewModel.kt
@@ -4,11 +4,8 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import hous.release.android.presentation.todo.edit.EditToDoViewModel
 import hous.release.android.presentation.todo.edit.UpdateToDoEvent
-import hous.release.android.presentation.todo.viewmodel.UpdateToDoUiState
 import hous.release.android.presentation.todo.viewmodel.UpdateToDoViewModel
 import hous.release.domain.entity.ApiResult
-import hous.release.domain.entity.HomyType
-import hous.release.domain.entity.response.ToDoUser
 import hous.release.domain.usecase.GetToDoUsersUseCase
 import hous.release.domain.usecase.PostAddToDoUseCase
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -62,32 +59,5 @@ class AddToDoVIewModel @Inject constructor(
                 is ApiResult.Empty -> Timber.e(IllegalArgumentException())
             }
         }
-    }
-
-    companion object {
-        private val dummyUiState = UpdateToDoUiState(
-            todoUsers = listOf(
-                ToDoUser().copy(
-                    homyType = HomyType.GREEN,
-                    nickname = "이준원",
-                    onBoardingId = 0
-                ),
-                ToDoUser().copy(
-                    homyType = HomyType.RED,
-                    nickname = "손연주",
-                    onBoardingId = 1
-                ),
-                ToDoUser().copy(
-                    homyType = HomyType.YELLOW,
-                    nickname = "이영주",
-                    onBoardingId = 2
-                ),
-                ToDoUser().copy(
-                    homyType = HomyType.BLUE,
-                    nickname = "강원용",
-                    onBoardingId = 3
-                )
-            )
-        )
     }
 }

--- a/app/src/main/java/hous/release/android/presentation/todo/add/AddToDoVIewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/add/AddToDoVIewModel.kt
@@ -2,6 +2,8 @@ package hous.release.android.presentation.todo.add
 
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import hous.release.android.presentation.todo.edit.EditToDoViewModel
+import hous.release.android.presentation.todo.edit.UpdateToDoEvent
 import hous.release.android.presentation.todo.viewmodel.UpdateToDoUiState
 import hous.release.android.presentation.todo.viewmodel.UpdateToDoViewModel
 import hous.release.domain.entity.ApiResult
@@ -9,6 +11,8 @@ import hous.release.domain.entity.HomyType
 import hous.release.domain.entity.response.ToDoUser
 import hous.release.domain.usecase.GetToDoUsersUseCase
 import hous.release.domain.usecase.PostAddToDoUseCase
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -19,6 +23,9 @@ class AddToDoVIewModel @Inject constructor(
     private val getToDoUsersUseCase: GetToDoUsersUseCase,
     private val postAddToDoUseCase: PostAddToDoUseCase
 ) : UpdateToDoViewModel() {
+
+    private val _uiEvent = MutableSharedFlow<UpdateToDoEvent>()
+    val uiEvent = _uiEvent.asSharedFlow()
 
     init {
         viewModelScope.launch {
@@ -41,8 +48,17 @@ class AddToDoVIewModel @Inject constructor(
             toDoName = todoName.value
         ).collect { apiResult ->
             when (apiResult) {
-                is ApiResult.Success -> Timber.i(apiResult.data)
-                is ApiResult.Error -> Timber.e(apiResult.msg)
+                is ApiResult.Success -> {
+                    Timber.i(apiResult.data)
+                    _uiEvent.emit(UpdateToDoEvent.Finish)
+                }
+                is ApiResult.Error -> {
+                    Timber.e(apiResult.msg)
+                    when (apiResult.msg) {
+                        EditToDoViewModel.DUPLICATED_ERROR_CODE -> _uiEvent.emit(UpdateToDoEvent.Duplicate)
+                        EditToDoViewModel.LIMITED_ERROR_CODE -> _uiEvent.emit(UpdateToDoEvent.Limit)
+                    }
+                }
                 is ApiResult.Empty -> Timber.e(IllegalArgumentException())
             }
         }

--- a/app/src/main/java/hous/release/android/presentation/todo/add/AddTodoUserScreen.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/add/AddTodoUserScreen.kt
@@ -10,7 +10,6 @@ import hous.release.android.util.extension.collectAsStateWithLifecycleRemember
 fun AddTodoUserScreen(
     viewModel: AddToDoVIewModel,
     showLoadingDialog: () -> Unit = {},
-    finish: () -> Boolean,
     name: String,
     hideKeyBoard: () -> Unit
 ) {
@@ -20,7 +19,6 @@ fun AddTodoUserScreen(
         checkUser = viewModel::checkUser,
         selectTodoDay = viewModel::selectTodoDay,
         showLoadingDialog = showLoadingDialog,
-        finish = finish,
         name = name,
         putToDo = viewModel::putTodo,
         hideKeyBoard = hideKeyBoard

--- a/app/src/main/java/hous/release/android/presentation/todo/detail/TodoLimitDialog.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/detail/TodoLimitDialog.kt
@@ -38,4 +38,8 @@ class TodoLimitDialog : DialogFragment() {
         super.onDestroyView()
         _binding = null
     }
+
+    companion object {
+        const val TAG = "TodoLimitDialogFragment"
+    }
 }

--- a/app/src/main/java/hous/release/android/presentation/todo/detail/daily/DailyFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/detail/daily/DailyFragment.kt
@@ -101,7 +101,7 @@ class DailyFragment : BindingFragment<FragmentDailyBinding>(R.layout.fragment_da
         binding.cvDailyFloatingButton.setContent {
             HousFloatingButton {
                 if (todoDetailViewModel.uiState.value.totalTodoCount == 60) {
-                    TodoLimitDialog().show(childFragmentManager, this.javaClass.name)
+                    TodoLimitDialog().show(childFragmentManager, TodoLimitDialog.TAG)
                     return@HousFloatingButton
                 }
                 findNavController().navigate(R.id.action_dailyFragment_to_addToDoFragment)

--- a/app/src/main/java/hous/release/android/presentation/todo/detail/member/MemberFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/detail/member/MemberFragment.kt
@@ -102,7 +102,7 @@ class MemberFragment : BindingFragment<FragmentMemberBinding>(R.layout.fragment_
         binding.cvMemberFloatingButton.setContent {
             HousFloatingButton {
                 if (todoDetailViewModel.uiState.value.totalTodoCount == 60) {
-                    TodoLimitDialog().show(childFragmentManager, this.javaClass.name)
+                    TodoLimitDialog().show(childFragmentManager, TodoLimitDialog.TAG)
                     return@HousFloatingButton
                 }
                 findNavController().navigate(R.id.action_memberFragment_to_addToDoFragment)

--- a/app/src/main/java/hous/release/android/presentation/todo/edit/EditToDoFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/edit/EditToDoFragment.kt
@@ -2,7 +2,6 @@ package hous.release.android.presentation.todo.edit
 
 import android.os.Bundle
 import android.view.View
-import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.addCallback
 import androidx.fragment.app.viewModels
@@ -13,6 +12,7 @@ import hous.release.android.R
 import hous.release.android.databinding.FragmentEditToDoBinding
 import hous.release.android.presentation.todo.detail.TodoLimitDialog
 import hous.release.android.util.KeyBoardUtil
+import hous.release.android.util.ToastMessageUtil
 import hous.release.android.util.binding.BindingFragment
 import hous.release.android.util.dialog.ConfirmClickListener
 import hous.release.android.util.dialog.LoadingDialogFragment
@@ -100,9 +100,10 @@ class EditToDoFragment : BindingFragment<FragmentEditToDoBinding>(R.layout.fragm
                         TodoLimitDialog().show(childFragmentManager, TodoLimitDialog.TAG)
                     }
                     UpdateToDoEvent.Duplicate -> {
-                        // TODO 확장함수 쓰기
-                        Toast.makeText(requireContext(), requireContext().getString(R.string.to_do_duplicate_toast_msg), Toast.LENGTH_SHORT)
-                            .show()
+                        ToastMessageUtil.showToast(
+                            requireContext(),
+                            getString(R.string.to_do_duplicate_toast_msg)
+                        )
                     }
                 }
             }

--- a/app/src/main/java/hous/release/android/presentation/todo/edit/EditToDoFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/edit/EditToDoFragment.kt
@@ -112,11 +112,11 @@ class EditToDoFragment : BindingFragment<FragmentEditToDoBinding>(R.layout.fragm
 
     private fun initBackButtonListener() {
         requireActivity().onBackPressedDispatcher.addCallback {
-            showOutDialog()
+            if (viewModel.isChangeToDoName()) showOutDialog()
         }.also { callback -> onBackPressedCallback = callback }
 
         binding.btnEditToDoBack.setOnClickListener {
-            showOutDialog()
+            if (viewModel.isChangeToDoName()) showOutDialog()
         }
     }
 

--- a/app/src/main/java/hous/release/android/presentation/todo/edit/EditToDoFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/edit/EditToDoFragment.kt
@@ -2,6 +2,7 @@ package hous.release.android.presentation.todo.edit
 
 import android.os.Bundle
 import android.view.View
+import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.addCallback
 import androidx.fragment.app.viewModels
@@ -10,6 +11,7 @@ import androidx.navigation.fragment.navArgs
 import dagger.hilt.android.AndroidEntryPoint
 import hous.release.android.R
 import hous.release.android.databinding.FragmentEditToDoBinding
+import hous.release.android.presentation.todo.detail.TodoLimitDialog
 import hous.release.android.util.KeyBoardUtil
 import hous.release.android.util.binding.BindingFragment
 import hous.release.android.util.dialog.ConfirmClickListener
@@ -34,6 +36,7 @@ class EditToDoFragment : BindingFragment<FragmentEditToDoBinding>(R.layout.fragm
         initToDoUserScreen()
         initBackButtonListener()
         collectTodoName()
+        collectUiEvent()
         initEditTextClearFocus()
     }
 
@@ -66,10 +69,6 @@ class EditToDoFragment : BindingFragment<FragmentEditToDoBinding>(R.layout.fragm
                 EditTodoUserScreen(
                     viewModel = viewModel,
                     showLoadingDialog = ::showLoadingDialog,
-                    finish = {
-                        (childFragmentManager.findFragmentByTag(LoadingDialogFragment.TAG) as? LoadingDialogFragment)?.dismiss()
-                        findNavController().popBackStack()
-                    },
                     name = getString(R.string.to_do_save_button),
                     hideKeyBoard = ::hideKeyBoard
                 )
@@ -85,6 +84,27 @@ class EditToDoFragment : BindingFragment<FragmentEditToDoBinding>(R.layout.fragm
         repeatOnStarted {
             viewModel.todoName.collect {
                 viewModel.setToDoNameState(isBlank = viewModel.isBlankToDoName())
+            }
+        }
+    }
+
+    private fun collectUiEvent() {
+        repeatOnStarted {
+            viewModel.uiEvent.collect { uiEvent ->
+                (childFragmentManager.findFragmentByTag(LoadingDialogFragment.TAG) as? LoadingDialogFragment)?.dismiss()
+                when (uiEvent) {
+                    UpdateToDoEvent.Finish -> {
+                        findNavController().popBackStack()
+                    }
+                    UpdateToDoEvent.Limit -> {
+                        TodoLimitDialog().show(childFragmentManager, TodoLimitDialog.TAG)
+                    }
+                    UpdateToDoEvent.Duplicate -> {
+                        // TODO 확장함수 쓰기
+                        Toast.makeText(requireContext(), requireContext().getString(R.string.to_do_duplicate_toast_msg), Toast.LENGTH_SHORT)
+                            .show()
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/hous/release/android/presentation/todo/edit/EditToDoUserScreen.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/edit/EditToDoUserScreen.kt
@@ -9,7 +9,6 @@ import hous.release.android.util.extension.collectAsStateWithLifecycleRemember
 @Composable
 fun EditTodoUserScreen(
     viewModel: EditToDoViewModel,
-    finish: () -> Boolean,
     showLoadingDialog: () -> Unit,
     name: String,
     hideKeyBoard: () -> Unit
@@ -20,7 +19,6 @@ fun EditTodoUserScreen(
         checkUser = viewModel::checkUser,
         selectTodoDay = viewModel::selectTodoDay,
         showLoadingDialog = showLoadingDialog,
-        finish = finish,
         name = name,
         putToDo = viewModel::putTodo,
         hideKeyBoard = hideKeyBoard

--- a/app/src/main/java/hous/release/android/presentation/todo/edit/EditToDoViewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/edit/EditToDoViewModel.kt
@@ -7,6 +7,8 @@ import hous.release.android.presentation.todo.viewmodel.UpdateToDoViewModel
 import hous.release.domain.entity.ApiResult
 import hous.release.domain.usecase.GetEditTodoContentUseCase
 import hous.release.domain.usecase.PutEditToDoUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -19,6 +21,8 @@ class EditToDoViewModel @Inject constructor(
 ) :
     UpdateToDoViewModel() {
     private var todoId = -1
+    private val _todoHint = MutableStateFlow("")
+    val todoHint = _todoHint.asStateFlow()
     override fun putTodo() = viewModelScope.launch {
         putEditToDoUseCase(
             todoId = todoId,
@@ -42,6 +46,7 @@ class EditToDoViewModel @Inject constructor(
                     is ApiResult.Success -> _uiState.update { uiState ->
                         val data = apiResult.data
                         todoName.value = data.name
+                        _todoHint.update { data.name }
                         uiState.copy(
                             isPushNotification = data.isPushNotification,
                             buttonState = ButtonState.ACTIVE,

--- a/app/src/main/java/hous/release/android/presentation/todo/edit/EditToDoViewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/edit/EditToDoViewModel.kt
@@ -61,4 +61,15 @@ class EditToDoViewModel @Inject constructor(
             }
         }
     }
+
+    companion object {
+        const val DUPLICATED_ERROR_CODE = "409"
+        const val LIMITED_ERROR_CODE = "403"
+    }
+}
+
+sealed class UpdateToDoEvent {
+    object Duplicate : UpdateToDoEvent()
+    object Limit : UpdateToDoEvent()
+    object Finish : UpdateToDoEvent()
 }

--- a/app/src/main/java/hous/release/android/presentation/todo/edit/EditToDoViewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/edit/EditToDoViewModel.kt
@@ -78,6 +78,8 @@ class EditToDoViewModel @Inject constructor(
         }
     }
 
+    fun isChangeToDoName() = (todoHint.value == todoName.value)
+
     companion object {
         const val DUPLICATED_ERROR_CODE = "409"
         const val LIMITED_ERROR_CODE = "403"

--- a/app/src/main/java/hous/release/android/presentation/todo/edit/EditToDoViewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/edit/EditToDoViewModel.kt
@@ -7,7 +7,9 @@ import hous.release.android.presentation.todo.viewmodel.UpdateToDoViewModel
 import hous.release.domain.entity.ApiResult
 import hous.release.domain.usecase.GetEditTodoContentUseCase
 import hous.release.domain.usecase.PutEditToDoUseCase
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -21,8 +23,13 @@ class EditToDoViewModel @Inject constructor(
 ) :
     UpdateToDoViewModel() {
     private var todoId = -1
+
     private val _todoHint = MutableStateFlow("")
     val todoHint = _todoHint.asStateFlow()
+
+    private val _uiEvent = MutableSharedFlow<UpdateToDoEvent>()
+    val uiEvent = _uiEvent.asSharedFlow()
+
     override fun putTodo() = viewModelScope.launch {
         putEditToDoUseCase(
             todoId = todoId,
@@ -31,8 +38,17 @@ class EditToDoViewModel @Inject constructor(
             toDoName = todoName.value
         ).collect { apiResult ->
             when (apiResult) {
-                is ApiResult.Success -> Timber.i(apiResult.data)
-                is ApiResult.Error -> Timber.e(apiResult.msg)
+                is ApiResult.Success -> {
+                    Timber.i(apiResult.data)
+                    _uiEvent.emit(UpdateToDoEvent.Finish)
+                }
+                is ApiResult.Error -> {
+                    Timber.e(apiResult.msg)
+                    when (apiResult.msg) {
+                        DUPLICATED_ERROR_CODE -> _uiEvent.emit(UpdateToDoEvent.Duplicate)
+                        LIMITED_ERROR_CODE -> _uiEvent.emit(UpdateToDoEvent.Limit)
+                    }
+                }
                 is ApiResult.Empty -> Timber.e(IllegalArgumentException())
             }
         }

--- a/app/src/main/java/hous/release/android/presentation/todo/viewmodel/UpdateToDoViewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/todo/viewmodel/UpdateToDoViewModel.kt
@@ -102,7 +102,7 @@ abstract class UpdateToDoViewModel : ViewModel() {
 data class UpdateToDoUiState(
     val selectedUsers: List<ToDoUser> = emptyList(),
     val todoUsers: List<ToDoUser> = emptyList(),
-    val isPushNotification: Boolean = false,
+    val isPushNotification: Boolean = true,
     val buttonState: ButtonState = ButtonState.INACTIVE,
     val isBlankTodoName: Boolean = true
 )

--- a/app/src/main/java/hous/release/android/util/component/ToDoButton.kt
+++ b/app/src/main/java/hous/release/android/util/component/ToDoButton.kt
@@ -34,7 +34,6 @@ fun ToDoButton(
     buttonState: ButtonState,
     name: String,
     showLoadingDialog: () -> Unit,
-    finish: () -> Boolean,
     putToDo: () -> Job,
     coroutineScope: CoroutineScope
 ) {
@@ -50,8 +49,7 @@ fun ToDoButton(
             .clickable(buttonState == ButtonState.ACTIVE) {
                 coroutineScope.launch {
                     showLoadingDialog()
-                    putToDo().join()
-                    finish()
+                    putToDo()
                 }
             },
         contentAlignment = Alignment.BottomCenter

--- a/app/src/main/java/hous/release/android/util/component/ToDoUserScreen.kt
+++ b/app/src/main/java/hous/release/android/util/component/ToDoUserScreen.kt
@@ -32,7 +32,6 @@ fun TodoUserScreen(
     checkUser: (Int) -> Unit,
     selectTodoDay: (Int, Int) -> Unit,
     showLoadingDialog: () -> Unit,
-    finish: () -> Boolean,
     name: String,
     putToDo: () -> Job,
     hideKeyBoard: () -> Unit
@@ -99,7 +98,6 @@ fun TodoUserScreen(
                 buttonState = uiState.buttonState,
                 name = name,
                 showLoadingDialog = showLoadingDialog,
-                finish = finish,
                 putToDo = putToDo,
                 coroutineScope = rememberCoroutineScope()
             )

--- a/app/src/main/java/hous/release/android/util/component/ToDoUserScreen.kt
+++ b/app/src/main/java/hous/release/android/util/component/ToDoUserScreen.kt
@@ -47,6 +47,7 @@ fun TodoUserScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .padding(bottom = 83.dp)
                 .clickable(interactionSource = interactionSource, indication = null) {
                     hideKeyBoard()
                 }
@@ -87,7 +88,6 @@ fun TodoUserScreen(
                     Divider(thickness = 1.dp, color = colorResource(id = R.color.hous_g_2))
                 }
             }
-            Spacer(modifier = Modifier.size(65.dp))
         }
         Row(
             modifier = Modifier

--- a/app/src/main/res/layout/fragment_edit_to_do.xml
+++ b/app/src/main/res/layout/fragment_edit_to_do.xml
@@ -62,7 +62,7 @@
             android:layout_marginHorizontal="18dp"
             android:layout_marginTop="32dp"
             android:background="@null"
-            android:hint="@string/to_do_text_field_hint"
+            android:hint="@{vm.todoHint}"
             android:importantForAutofill="no"
             android:inputType="text"
             android:maxLength="15"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -205,6 +205,7 @@
     <string name="dialog_cancel">취소하기</string>
 
     <!-- To Do-add,edit-->
+    <string name="to_do_duplicate_toast_msg">똑같은 이름의 to-do가 있어요!</string>
     <string name="to_do_manager">담당자</string>
     <string name="to_do_add_title">새로운 to-do 추가</string>
     <string name="to_do_edit_title">to-do 수정</string>

--- a/data/src/main/java/hous/release/data/repository/TodoRepositoryImpl.kt
+++ b/data/src/main/java/hous/release/data/repository/TodoRepositoryImpl.kt
@@ -77,13 +77,15 @@ class TodoRepositoryImpl @Inject constructor(
             updateTodoUsers = todoUsers.map { toDoUser -> toDoUser.toAddedToDoUser() }
         )
         if (!response.success) {
-            emit(ApiResult.Error(response.message))
+            Timber.e("$response")
+            emit(ApiResult.Error("${response.status}"))
             return@flow
         }
         emit(ApiResult.Success(response.message))
     }.catch { e ->
         if (e is HttpException) {
-            emit(ApiResult.Error(e.message))
+            Timber.e(e)
+            emit(ApiResult.Error("${e.code()}"))
         }
     }.flowOn(ioDispatcher)
 
@@ -126,13 +128,15 @@ class TodoRepositoryImpl @Inject constructor(
             updateTodoUsers = todoUsers.map { toDoUser -> toDoUser.toAddedToDoUser() }
         )
         if (!response.success) {
-            emit(ApiResult.Error(response.message))
+            Timber.e("$response")
+            emit(ApiResult.Error("${response.status}"))
             return@flow
         }
         emit(ApiResult.Success(response.message))
     }.catch { e ->
         if (e is HttpException) {
-            emit(ApiResult.Error(e.message))
+            Timber.e(e)
+            emit(ApiResult.Error("${e.code()}"))
         }
     }.flowOn(ioDispatcher)
 }


### PR DESCRIPTION
## 관련 이슈
- closed #153 

## 작업 영상
https://user-images.githubusercontent.com/87055456/205509610-a6ca5f6f-3a8c-412e-9fd4-c3aa1c5cee8a.mp4  

https://user-images.githubusercontent.com/87055456/205509613-62486712-33d4-4188-a9c1-99ee6e8cfb10.mp4  

## 작업한 내용
- todo 수정/추가 스크롤 문제 해결
- todo 수정 - hint 기존 to-do명 노출
- 알림 버튼 클릭 시 on/off 확인. (on으로 default)
- Todo 추가 시 60개 초과일 때 다이얼로그 호출하는 것도 추가
-  to-do 추가/수정 시 중복값 입력시 toast 메세지 띄우기
## PR 포인트
- todo 진짜 끝?!
- 저 내일 제주도 갑니다용~ 제주도에서 최종 매무리 할게유 히히
- 머지하기 전에 연주 토스트유틸로 바꿀게연
- @KWY0218 javaclass.name -> `TodoLimitDialog.TAG`로 바꿨어연
