### PR TITLE
#159 [feat] 방만들기/방참여하기, 우리집 별명 바꾸기, 탈퇴하기 터치 중복 막기

### DIFF
--- a/app/src/main/java/hous/release/android/presentation/enter_room/create_room/CreateRoomFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/enter_room/create_room/CreateRoomFragment.kt
@@ -8,10 +8,10 @@ import dagger.hilt.android.AndroidEntryPoint
 import hous.release.android.R
 import hous.release.android.databinding.FragmentCreateRoomBinding
 import hous.release.android.util.KeyBoardUtil
+import hous.release.android.util.UiEvent
 import hous.release.android.util.binding.BindingFragment
 import hous.release.android.util.dialog.LoadingDialogFragment
 import hous.release.android.util.extension.repeatOnStarted
-import hous.release.domain.entity.RequestState
 
 @AndroidEntryPoint
 class CreateRoomFragment :
@@ -24,7 +24,7 @@ class CreateRoomFragment :
         binding.viewModel = viewModel
         initEditTextClearFocus()
         initBackBtnClickListener()
-        initCreateRoomRequestStateCollector()
+        initCreateRoomUiEventCollector()
     }
 
     override fun onDestroyView() {
@@ -42,18 +42,18 @@ class CreateRoomFragment :
         binding.btnCreateRoomBack.setOnClickListener { findNavController().popBackStack() }
     }
 
-    private fun initCreateRoomRequestStateCollector() {
+    private fun initCreateRoomUiEventCollector() {
         repeatOnStarted {
-            viewModel.createRoomRequestState.collect { requestState ->
-                when (requestState) {
-                    RequestState.LOADING -> {
+            viewModel.createRoomUiEvent.collect { uiEvent ->
+                when (uiEvent) {
+                    UiEvent.LOADING -> {
                         loadingDialog.show(childFragmentManager, LoadingDialogFragment.TAG)
                     }
-                    RequestState.SUCCESS -> {
+                    UiEvent.SUCCESS -> {
                         loadingDialog.dismiss()
                         CreateRoomDialogFragment().show(childFragmentManager, this.javaClass.name)
                     }
-                    RequestState.FAILED -> {
+                    UiEvent.ERROR -> {
                         loadingDialog.dismiss()
                     }
                 }

--- a/app/src/main/java/hous/release/android/presentation/enter_room/create_room/CreateRoomFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/enter_room/create_room/CreateRoomFragment.kt
@@ -9,19 +9,22 @@ import hous.release.android.R
 import hous.release.android.databinding.FragmentCreateRoomBinding
 import hous.release.android.util.KeyBoardUtil
 import hous.release.android.util.binding.BindingFragment
+import hous.release.android.util.dialog.LoadingDialogFragment
 import hous.release.android.util.extension.repeatOnStarted
+import hous.release.domain.entity.RequestState
 
 @AndroidEntryPoint
 class CreateRoomFragment :
     BindingFragment<FragmentCreateRoomBinding>(R.layout.fragment_create_room) {
     private val viewModel by activityViewModels<CreateRoomViewModel>()
+    private val loadingDialog = LoadingDialogFragment()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.viewModel = viewModel
         initEditTextClearFocus()
         initBackBtnClickListener()
-        initIsSuccessCreateRoomCollector()
+        initCreateRoomRequestStateCollector()
     }
 
     override fun onDestroyView() {
@@ -39,11 +42,20 @@ class CreateRoomFragment :
         binding.btnCreateRoomBack.setOnClickListener { findNavController().popBackStack() }
     }
 
-    private fun initIsSuccessCreateRoomCollector() {
+    private fun initCreateRoomRequestStateCollector() {
         repeatOnStarted {
-            viewModel.isSuccessCreateRoom.collect { isSuccess ->
-                if (isSuccess) {
-                    CreateRoomDialogFragment().show(childFragmentManager, this.javaClass.name)
+            viewModel.createRoomRequestState.collect { requestState ->
+                when (requestState) {
+                    RequestState.LOADING -> {
+                        loadingDialog.show(childFragmentManager, LoadingDialogFragment.TAG)
+                    }
+                    RequestState.SUCCESS -> {
+                        loadingDialog.dismiss()
+                        CreateRoomDialogFragment().show(childFragmentManager, this.javaClass.name)
+                    }
+                    RequestState.FAILED -> {
+                        loadingDialog.dismiss()
+                    }
                 }
             }
         }

--- a/app/src/main/java/hous/release/android/presentation/enter_room/create_room/CreateRoomViewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/enter_room/create_room/CreateRoomViewModel.kt
@@ -3,6 +3,7 @@ package hous.release.android.presentation.enter_room.create_room
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import hous.release.domain.entity.RequestState
 import hous.release.domain.entity.SplashState
 import hous.release.domain.entity.response.NewRoom
 import hous.release.domain.repository.EnterRoomRepository
@@ -22,8 +23,8 @@ class CreateRoomViewModel @Inject constructor(
 ) : ViewModel() {
     val roomName = MutableStateFlow<String>("")
 
-    private val _isSuccessCreateRoom = MutableSharedFlow<Boolean>()
-    val isSuccessCreateRoom: SharedFlow<Boolean> = _isSuccessCreateRoom.asSharedFlow()
+    private val _createRoomRequestState = MutableSharedFlow<RequestState>()
+    val createRoomRequestState: SharedFlow<RequestState> = _createRoomRequestState.asSharedFlow()
 
     var newRoomInfo: NewRoom = NewRoom()
         private set
@@ -34,13 +35,15 @@ class CreateRoomViewModel @Inject constructor(
 
     fun postCreateRoom() {
         viewModelScope.launch {
+            _createRoomRequestState.emit(RequestState.LOADING)
             enterRoomRepository.postCreateRoom(roomName.value)
                 .onSuccess { response ->
                     newRoomInfo = response
                     setSplashStateUseCase(SplashState.MAIN)
-                    _isSuccessCreateRoom.emit(true)
+                    _createRoomRequestState.emit(RequestState.SUCCESS)
                 }
                 .onFailure {
+                    _createRoomRequestState.emit(RequestState.FAILED)
                     Timber.d(it.message.toString())
                 }
         }

--- a/app/src/main/java/hous/release/android/presentation/enter_room/create_room/CreateRoomViewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/enter_room/create_room/CreateRoomViewModel.kt
@@ -3,7 +3,7 @@ package hous.release.android.presentation.enter_room.create_room
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import hous.release.domain.entity.RequestState
+import hous.release.android.util.UiEvent
 import hous.release.domain.entity.SplashState
 import hous.release.domain.entity.response.NewRoom
 import hous.release.domain.repository.EnterRoomRepository
@@ -23,8 +23,8 @@ class CreateRoomViewModel @Inject constructor(
 ) : ViewModel() {
     val roomName = MutableStateFlow<String>("")
 
-    private val _createRoomRequestState = MutableSharedFlow<RequestState>()
-    val createRoomRequestState: SharedFlow<RequestState> = _createRoomRequestState.asSharedFlow()
+    private val _createRoomUiEvent = MutableSharedFlow<UiEvent>()
+    val createRoomUiEvent: SharedFlow<UiEvent> = _createRoomUiEvent.asSharedFlow()
 
     var newRoomInfo: NewRoom = NewRoom()
         private set
@@ -35,15 +35,15 @@ class CreateRoomViewModel @Inject constructor(
 
     fun postCreateRoom() {
         viewModelScope.launch {
-            _createRoomRequestState.emit(RequestState.LOADING)
+            _createRoomUiEvent.emit(UiEvent.LOADING)
             enterRoomRepository.postCreateRoom(roomName.value)
                 .onSuccess { response ->
                     newRoomInfo = response
                     setSplashStateUseCase(SplashState.MAIN)
-                    _createRoomRequestState.emit(RequestState.SUCCESS)
+                    _createRoomUiEvent.emit(UiEvent.SUCCESS)
                 }
                 .onFailure {
-                    _createRoomRequestState.emit(RequestState.FAILED)
+                    _createRoomUiEvent.emit(UiEvent.ERROR)
                     Timber.d(it.message.toString())
                 }
         }

--- a/app/src/main/java/hous/release/android/presentation/enter_room/enter_room_code/EnterRoomCodeDialogFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/enter_room/enter_room_code/EnterRoomCodeDialogFragment.kt
@@ -11,9 +11,9 @@ import androidx.fragment.app.activityViewModels
 import hous.release.android.R
 import hous.release.android.databinding.DialogEnterRoomCodeBinding
 import hous.release.android.presentation.main.MainActivity
+import hous.release.android.util.UiEvent
 import hous.release.android.util.dialog.LoadingDialogFragment
 import hous.release.android.util.extension.repeatOnStarted
-import hous.release.domain.entity.RequestState
 
 class EnterRoomCodeDialogFragment : DialogFragment() {
     private var _binding: DialogEnterRoomCodeBinding? = null
@@ -40,7 +40,7 @@ class EnterRoomCodeDialogFragment : DialogFragment() {
         super.onViewCreated(view, savedInstanceState)
         binding.viewModel = viewModel
         initLayout()
-        initEnterRoomRequestStateCollector()
+        initEnterRoomUiEventCollector()
         initCloseClickListener()
     }
 
@@ -56,20 +56,20 @@ class EnterRoomCodeDialogFragment : DialogFragment() {
         }
     }
 
-    private fun initEnterRoomRequestStateCollector() {
+    private fun initEnterRoomUiEventCollector() {
         repeatOnStarted {
-            viewModel.enterRoomRequestState.collect { requestState ->
-                when (requestState) {
-                    RequestState.LOADING -> {
+            viewModel.enterRoomUiEvent.collect { uiEvent ->
+                when (uiEvent) {
+                    UiEvent.LOADING -> {
                         loadingDialog.show(childFragmentManager, LoadingDialogFragment.TAG)
                     }
-                    RequestState.SUCCESS -> {
+                    UiEvent.SUCCESS -> {
                         loadingDialog.dismiss()
                         dismiss()
                         requireActivity().finish()
                         startActivity(Intent(requireContext(), MainActivity::class.java))
                     }
-                    RequestState.FAILED -> {
+                    UiEvent.ERROR -> {
                         loadingDialog.dismiss()
                     }
                 }

--- a/app/src/main/java/hous/release/android/presentation/enter_room/enter_room_code/EnterRoomCodeDialogFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/enter_room/enter_room_code/EnterRoomCodeDialogFragment.kt
@@ -11,14 +11,16 @@ import androidx.fragment.app.activityViewModels
 import hous.release.android.R
 import hous.release.android.databinding.DialogEnterRoomCodeBinding
 import hous.release.android.presentation.main.MainActivity
+import hous.release.android.util.dialog.LoadingDialogFragment
 import hous.release.android.util.extension.repeatOnStarted
-import kotlinx.coroutines.flow.filter
+import hous.release.domain.entity.RequestState
 
 class EnterRoomCodeDialogFragment : DialogFragment() {
     private var _binding: DialogEnterRoomCodeBinding? = null
     val binding get() = _binding ?: error(getString(R.string.binding_error))
 
     private val viewModel by activityViewModels<EnterRoomCodeViewModel>()
+    private val loadingDialog = LoadingDialogFragment()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -38,7 +40,7 @@ class EnterRoomCodeDialogFragment : DialogFragment() {
         super.onViewCreated(view, savedInstanceState)
         binding.viewModel = viewModel
         initLayout()
-        initIsSuccessEnterRoomCollector()
+        initEnterRoomRequestStateCollector()
         initCloseClickListener()
     }
 
@@ -54,12 +56,23 @@ class EnterRoomCodeDialogFragment : DialogFragment() {
         }
     }
 
-    private fun initIsSuccessEnterRoomCollector() {
+    private fun initEnterRoomRequestStateCollector() {
         repeatOnStarted {
-            viewModel.isSuccessEnterRoom.filter { isSuccess -> isSuccess }.collect {
-                dismiss()
-                requireActivity().finish()
-                startActivity(Intent(requireContext(), MainActivity::class.java))
+            viewModel.enterRoomRequestState.collect { requestState ->
+                when (requestState) {
+                    RequestState.LOADING -> {
+                        loadingDialog.show(childFragmentManager, LoadingDialogFragment.TAG)
+                    }
+                    RequestState.SUCCESS -> {
+                        loadingDialog.dismiss()
+                        dismiss()
+                        requireActivity().finish()
+                        startActivity(Intent(requireContext(), MainActivity::class.java))
+                    }
+                    RequestState.FAILED -> {
+                        loadingDialog.dismiss()
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/hous/release/android/presentation/enter_room/enter_room_code/EnterRoomCodeViewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/enter_room/enter_room_code/EnterRoomCodeViewModel.kt
@@ -3,6 +3,7 @@ package hous.release.android.presentation.enter_room.enter_room_code
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import hous.release.domain.entity.RequestState
 import hous.release.domain.entity.SplashState
 import hous.release.domain.entity.response.Room
 import hous.release.domain.repository.EnterRoomRepository
@@ -31,8 +32,8 @@ class EnterRoomCodeViewModel @Inject constructor(
     private val _roomInfo = MutableStateFlow(Room())
     val roomInfo: StateFlow<Room> = _roomInfo.asStateFlow()
 
-    private val _isSuccessEnterRoom = MutableSharedFlow<Boolean>()
-    val isSuccessEnterRoom: SharedFlow<Boolean> = _isSuccessEnterRoom.asSharedFlow()
+    private val _enterRoomRequestState = MutableSharedFlow<RequestState>()
+    val enterRoomRequestState: SharedFlow<RequestState> = _enterRoomRequestState.asSharedFlow()
 
     private val _isFullCapacity = MutableSharedFlow<Boolean>()
     val isFullCapacity: SharedFlow<Boolean> = _isFullCapacity.asSharedFlow()
@@ -56,13 +57,15 @@ class EnterRoomCodeViewModel @Inject constructor(
 
     fun postEnterRoomId() {
         viewModelScope.launch {
+            _enterRoomRequestState.emit(RequestState.LOADING)
             enterRoomRepository.postEnterRoomId(roomInfo.value.roomId.toString())
                 .onSuccess {
                     setSplashStateUseCase(SplashState.MAIN)
-                    _isSuccessEnterRoom.emit(true)
+                    _enterRoomRequestState.emit(RequestState.SUCCESS)
                 }
                 .onFailure { throwable ->
                     Timber.d(throwable.message)
+                    _enterRoomRequestState.emit(RequestState.FAILED)
                     if (throwable is HttpException) {
                         when (throwable.code()) {
                             FULL_CAPACITY -> _isFullCapacity.emit(true)

--- a/app/src/main/java/hous/release/android/presentation/enter_room/enter_room_code/EnterRoomCodeViewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/enter_room/enter_room_code/EnterRoomCodeViewModel.kt
@@ -3,7 +3,7 @@ package hous.release.android.presentation.enter_room.enter_room_code
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import hous.release.domain.entity.RequestState
+import hous.release.android.util.UiEvent
 import hous.release.domain.entity.SplashState
 import hous.release.domain.entity.response.Room
 import hous.release.domain.repository.EnterRoomRepository
@@ -32,8 +32,8 @@ class EnterRoomCodeViewModel @Inject constructor(
     private val _roomInfo = MutableStateFlow(Room())
     val roomInfo: StateFlow<Room> = _roomInfo.asStateFlow()
 
-    private val _enterRoomRequestState = MutableSharedFlow<RequestState>()
-    val enterRoomRequestState: SharedFlow<RequestState> = _enterRoomRequestState.asSharedFlow()
+    private val _enterRoomUiEvent = MutableSharedFlow<UiEvent>()
+    val enterRoomUiEvent: SharedFlow<UiEvent> = _enterRoomUiEvent.asSharedFlow()
 
     private val _isFullCapacity = MutableSharedFlow<Boolean>()
     val isFullCapacity: SharedFlow<Boolean> = _isFullCapacity.asSharedFlow()
@@ -57,15 +57,15 @@ class EnterRoomCodeViewModel @Inject constructor(
 
     fun postEnterRoomId() {
         viewModelScope.launch {
-            _enterRoomRequestState.emit(RequestState.LOADING)
+            _enterRoomUiEvent.emit(UiEvent.LOADING)
             enterRoomRepository.postEnterRoomId(roomInfo.value.roomId.toString())
                 .onSuccess {
                     setSplashStateUseCase(SplashState.MAIN)
-                    _enterRoomRequestState.emit(RequestState.SUCCESS)
+                    _enterRoomUiEvent.emit(UiEvent.SUCCESS)
                 }
                 .onFailure { throwable ->
                     Timber.d(throwable.message)
-                    _enterRoomRequestState.emit(RequestState.FAILED)
+                    _enterRoomUiEvent.emit(UiEvent.ERROR)
                     if (throwable is HttpException) {
                         when (throwable.code()) {
                             FULL_CAPACITY -> _isFullCapacity.emit(true)

--- a/app/src/main/java/hous/release/android/presentation/hous/EditHousNameActivity.kt
+++ b/app/src/main/java/hous/release/android/presentation/hous/EditHousNameActivity.kt
@@ -10,17 +10,20 @@ import hous.release.android.presentation.hous.HousFragment.Companion.ROOM_NAME
 import hous.release.android.util.KeyBoardUtil
 import hous.release.android.util.binding.BindingActivity
 import hous.release.android.util.dialog.ConfirmClickListener
+import hous.release.android.util.dialog.LoadingDialogFragment
 import hous.release.android.util.dialog.WarningDialogFragment
 import hous.release.android.util.dialog.WarningDialogFragment.Companion.CONFIRM_ACTION
 import hous.release.android.util.dialog.WarningDialogFragment.Companion.DIALOG_WARNING
 import hous.release.android.util.dialog.WarningDialogFragment.Companion.WARNING_TYPE
 import hous.release.android.util.dialog.WarningType
 import hous.release.android.util.extension.repeatOnStarted
+import hous.release.domain.entity.RequestState
 
 @AndroidEntryPoint
 class EditHousNameActivity :
     BindingActivity<ActivityEditHousNameBinding>(R.layout.activity_edit_hous_name) {
     private val viewModel by viewModels<EditHousNameViewModel>()
+    private val loadingDialog = LoadingDialogFragment()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -28,7 +31,7 @@ class EditHousNameActivity :
         initEditTextClearFocus()
         initBackBtnClickListener()
         initOriginalRoomName()
-        initIsSuccessEditHousNameCollector()
+        initEditHousNameRequestStateCollector()
     }
 
     private fun initEditTextClearFocus() {
@@ -69,10 +72,21 @@ class EditHousNameActivity :
         )
     }
 
-    private fun initIsSuccessEditHousNameCollector() {
+    private fun initEditHousNameRequestStateCollector() {
         repeatOnStarted {
-            viewModel.isSuccessEditHousName.collect { isSuccess ->
-                if (isSuccess) finish()
+            viewModel.editHousNameRequestState.collect { requestState ->
+                when (requestState) {
+                    RequestState.LOADING -> {
+                        loadingDialog.show(supportFragmentManager, LoadingDialogFragment.TAG)
+                    }
+                    RequestState.SUCCESS -> {
+                        loadingDialog.dismiss()
+                        finish()
+                    }
+                    RequestState.FAILED -> {
+                        loadingDialog.dismiss()
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/hous/release/android/presentation/hous/EditHousNameActivity.kt
+++ b/app/src/main/java/hous/release/android/presentation/hous/EditHousNameActivity.kt
@@ -8,6 +8,7 @@ import hous.release.android.R
 import hous.release.android.databinding.ActivityEditHousNameBinding
 import hous.release.android.presentation.hous.HousFragment.Companion.ROOM_NAME
 import hous.release.android.util.KeyBoardUtil
+import hous.release.android.util.UiEvent
 import hous.release.android.util.binding.BindingActivity
 import hous.release.android.util.dialog.ConfirmClickListener
 import hous.release.android.util.dialog.LoadingDialogFragment
@@ -17,7 +18,6 @@ import hous.release.android.util.dialog.WarningDialogFragment.Companion.DIALOG_W
 import hous.release.android.util.dialog.WarningDialogFragment.Companion.WARNING_TYPE
 import hous.release.android.util.dialog.WarningType
 import hous.release.android.util.extension.repeatOnStarted
-import hous.release.domain.entity.RequestState
 
 @AndroidEntryPoint
 class EditHousNameActivity :
@@ -31,7 +31,7 @@ class EditHousNameActivity :
         initEditTextClearFocus()
         initBackBtnClickListener()
         initOriginalRoomName()
-        initEditHousNameRequestStateCollector()
+        initEditHousNameUiEventCollector()
     }
 
     private fun initEditTextClearFocus() {
@@ -72,18 +72,18 @@ class EditHousNameActivity :
         )
     }
 
-    private fun initEditHousNameRequestStateCollector() {
+    private fun initEditHousNameUiEventCollector() {
         repeatOnStarted {
-            viewModel.editHousNameRequestState.collect { requestState ->
-                when (requestState) {
-                    RequestState.LOADING -> {
+            viewModel.editHousNameUiEvent.collect { uiEvent ->
+                when (uiEvent) {
+                    UiEvent.LOADING -> {
                         loadingDialog.show(supportFragmentManager, LoadingDialogFragment.TAG)
                     }
-                    RequestState.SUCCESS -> {
+                    UiEvent.SUCCESS -> {
                         loadingDialog.dismiss()
                         finish()
                     }
-                    RequestState.FAILED -> {
+                    UiEvent.ERROR -> {
                         loadingDialog.dismiss()
                     }
                 }

--- a/app/src/main/java/hous/release/android/presentation/hous/EditHousNameViewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/hous/EditHousNameViewModel.kt
@@ -3,10 +3,12 @@ package hous.release.android.presentation.hous
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import hous.release.domain.entity.RequestState
 import hous.release.domain.repository.HousRepository
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -19,8 +21,8 @@ class EditHousNameViewModel @Inject constructor(
         private set
     val roomName = MutableStateFlow<String>("")
 
-    private val _isSuccessEditHousName = MutableStateFlow<Boolean>(false)
-    val isSuccessEditHousName: StateFlow<Boolean> = _isSuccessEditHousName.asStateFlow()
+    private val _editHousNameRequestState = MutableSharedFlow<RequestState>()
+    val editHousNameRequestState: SharedFlow<RequestState> = _editHousNameRequestState.asSharedFlow()
 
     fun initOriginalRoomName(name: String) {
         originalRoomName = name
@@ -31,11 +33,15 @@ class EditHousNameViewModel @Inject constructor(
 
     fun putHousName() {
         viewModelScope.launch {
+            _editHousNameRequestState.emit(RequestState.LOADING)
             housRepository.putHousName(roomName.value)
                 .onSuccess { isSuccess ->
-                    _isSuccessEditHousName.value = isSuccess
+                    _editHousNameRequestState.emit(RequestState.SUCCESS)
                 }
-                .onFailure { Timber.d(it.message.toString()) }
+                .onFailure {
+                    Timber.d(it.message.toString())
+                    _editHousNameRequestState.emit(RequestState.FAILED)
+                }
         }
     }
 }

--- a/app/src/main/java/hous/release/android/presentation/hous/EditHousNameViewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/hous/EditHousNameViewModel.kt
@@ -3,7 +3,7 @@ package hous.release.android.presentation.hous
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import hous.release.domain.entity.RequestState
+import hous.release.android.util.UiEvent
 import hous.release.domain.repository.HousRepository
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -21,8 +21,8 @@ class EditHousNameViewModel @Inject constructor(
         private set
     val roomName = MutableStateFlow<String>("")
 
-    private val _editHousNameRequestState = MutableSharedFlow<RequestState>()
-    val editHousNameRequestState: SharedFlow<RequestState> = _editHousNameRequestState.asSharedFlow()
+    private val _editHousNameUiEvent = MutableSharedFlow<UiEvent>()
+    val editHousNameUiEvent: SharedFlow<UiEvent> = _editHousNameUiEvent.asSharedFlow()
 
     fun initOriginalRoomName(name: String) {
         originalRoomName = name
@@ -33,14 +33,14 @@ class EditHousNameViewModel @Inject constructor(
 
     fun putHousName() {
         viewModelScope.launch {
-            _editHousNameRequestState.emit(RequestState.LOADING)
+            _editHousNameUiEvent.emit(UiEvent.LOADING)
             housRepository.putHousName(roomName.value)
                 .onSuccess { isSuccess ->
-                    _editHousNameRequestState.emit(RequestState.SUCCESS)
+                    _editHousNameUiEvent.emit(UiEvent.SUCCESS)
                 }
                 .onFailure {
                     Timber.d(it.message.toString())
-                    _editHousNameRequestState.emit(RequestState.FAILED)
+                    _editHousNameUiEvent.emit(UiEvent.ERROR)
                 }
         }
     }

--- a/app/src/main/java/hous/release/android/presentation/withdraw/WithdrawActivity.kt
+++ b/app/src/main/java/hous/release/android/presentation/withdraw/WithdrawActivity.kt
@@ -11,11 +11,11 @@ import hous.release.android.R
 import hous.release.android.databinding.ActivityWithdrawBinding
 import hous.release.android.presentation.login.LoginActivity
 import hous.release.android.util.ToastMessageUtil
+import hous.release.android.util.UiEvent
 import hous.release.android.util.binding.BindingActivity
 import hous.release.android.util.dialog.LoadingDialogFragment
 import hous.release.android.util.extension.repeatOnStarted
 import hous.release.domain.entity.FeedbackType
-import hous.release.domain.entity.RequestState
 
 @AndroidEntryPoint
 class WithdrawActivity :
@@ -27,7 +27,7 @@ class WithdrawActivity :
         super.onCreate(savedInstanceState)
         binding.vm = viewModel
         initBackBtnClickListener()
-        initWithdrawRequestStateCollector()
+        initWithdrawUiEventCollector()
         initWithdrawFeedbackSpinner()
     }
 
@@ -35,14 +35,14 @@ class WithdrawActivity :
         binding.btnWithdrawBack.setOnClickListener { finish() }
     }
 
-    private fun initWithdrawRequestStateCollector() {
+    private fun initWithdrawUiEventCollector() {
         repeatOnStarted {
-            viewModel.withdrawRequestState.collect { requestState ->
-                when (requestState) {
-                    RequestState.LOADING -> {
+            viewModel.withdrawUiEvent.collect { uiEvent ->
+                when (uiEvent) {
+                    UiEvent.LOADING -> {
                         loadingDialog.show(supportFragmentManager, LoadingDialogFragment.TAG)
                     }
-                    RequestState.SUCCESS -> {
+                    UiEvent.SUCCESS -> {
                         loadingDialog.dismiss()
                         ToastMessageUtil.showToast(
                             this@WithdrawActivity,
@@ -54,7 +54,7 @@ class WithdrawActivity :
                             }
                         )
                     }
-                    RequestState.FAILED -> {
+                    UiEvent.ERROR -> {
                         loadingDialog.dismiss()
                     }
                 }

--- a/app/src/main/java/hous/release/android/presentation/withdraw/WithdrawViewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/withdraw/WithdrawViewModel.kt
@@ -3,8 +3,8 @@ package hous.release.android.presentation.withdraw
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import hous.release.android.util.UiEvent
 import hous.release.domain.entity.FeedbackType
-import hous.release.domain.entity.RequestState
 import hous.release.domain.repository.AuthRepository
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -24,8 +24,8 @@ class WithdrawViewModel @Inject constructor(
 
     val isCheckedWithdraw = MutableStateFlow(false)
 
-    private val _withdrawRequestState = MutableSharedFlow<RequestState>()
-    val withdrawRequestState: SharedFlow<RequestState> = _withdrawRequestState.asSharedFlow()
+    private val _withdrawUiEvent = MutableSharedFlow<UiEvent>()
+    val withdrawUiEvent: SharedFlow<UiEvent> = _withdrawUiEvent.asSharedFlow()
 
     fun initFeedbackType(type: FeedbackType) {
         feedbackType = type
@@ -33,15 +33,15 @@ class WithdrawViewModel @Inject constructor(
 
     fun deleteUser() {
         viewModelScope.launch {
-            _withdrawRequestState.emit(RequestState.LOADING)
+            _withdrawUiEvent.emit(UiEvent.LOADING)
             authRepository.deleteUser(feedbackType = feedbackType, comment = comment.value)
                 .onSuccess { response ->
                     authRepository.clearLocalPref()
-                    _withdrawRequestState.emit(RequestState.SUCCESS)
+                    _withdrawUiEvent.emit(UiEvent.SUCCESS)
                 }
                 .onFailure {
                     Timber.d(it.message.toString())
-                    _withdrawRequestState.emit(RequestState.FAILED)
+                    _withdrawUiEvent.emit(UiEvent.ERROR)
                 }
         }
     }

--- a/app/src/main/java/hous/release/android/util/UiEvent.kt
+++ b/app/src/main/java/hous/release/android/util/UiEvent.kt
@@ -1,0 +1,5 @@
+package hous.release.android.util
+
+enum class UiEvent {
+    LOADING, SUCCESS, ERROR
+}

--- a/app/src/main/res/layout/activity_edit_hous_name.xml
+++ b/app/src/main/res/layout/activity_edit_hous_name.xml
@@ -36,10 +36,11 @@
             android:layout_marginTop="12dp"
             android:layout_marginEnd="8dp"
             android:onClick="@{()->vm.putHousName()}"
+            android:clickable="@{vm.roomName.length() == 0 ? false : true}"
             android:padding="8dp"
             android:text="@string/edit_hous_name_done"
             android:textAppearance="@style/B1"
-            android:textColor="@color/hous_blue"
+            android:textColor="@{vm.roomName.length() == 0 ? @color/hous_g_4 : @color/hous_blue}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -285,7 +285,7 @@
     <string name="settings_withdraw_desc">* 회원 탈퇴는 방 퇴사 이후 \'방만들기 화면\'에서 할 수 있어요!</string>
     <string name="settings_withdraw"><u>회원탈퇴</u></string>
     <string name="settings_feedback_email">hanzip001@gmail.com</string>
-    <string name="settings_feedback_subject">Hous- 문의사항</string>
+    <string name="settings_feedback_subject">[ 호미나라 피드백 ]</string>
     <string name="settings_feedback_content">\n\n\nDevice : %s\nOS Version : Android %s\nApp Version : %s\n-------------------------\n\n\n\n호미나라에 자유로운 피드백을 보내주세요!\n-------------------------</string>
     <string name="settings_feedback_empty_string"> </string>
     <string name="settings_info_link">https://sugared-lemming-812.notion.site/6d9d478df40b4a20811e0020c15af3bc</string>

--- a/domain/src/main/java/hous/release/domain/entity/RequestState.kt
+++ b/domain/src/main/java/hous/release/domain/entity/RequestState.kt
@@ -1,5 +1,0 @@
-package hous.release.domain.entity
-
-enum class RequestState {
-    LOADING, SUCCESS, FAILED
-}

--- a/domain/src/main/java/hous/release/domain/entity/RequestState.kt
+++ b/domain/src/main/java/hous/release/domain/entity/RequestState.kt
@@ -1,0 +1,5 @@
+package hous.release.domain.entity
+
+enum class RequestState {
+    LOADING, SUCCESS, FAILED
+}


### PR DESCRIPTION
## 관련 이슈
- closed #159

## 작업한 내용

-  탈퇴하기 클릭 시 - 로딩뷰 추가
-  방만들기 클릭 시 - 로딩뷰 추가
-  방코드로 참여하기 클릭 시 - 로딩뷰 추가
-  우리집 별명 바꾸기 저장 버튼 클릭 시 - 로딩 뷰 추가
-  하우스명 수정 시 - 0자 일 때 저장 버튼 비활성화
-  하우스 피드백 제목 수정

## PR 포인트
- 서버 요청 상태를 담는 RequestState Enum class 를 추가했는데 아래 사진에서 보다시피 glide 라이브러리에서 쓰는 enumclass와 이름이 겹쳐서 수정을 할지 아니면 어차피 기본이 아니라 라이브러리의 enum이니까 그냥 지금 이름 그대로 가져갈지 고민입니다... 만약 수정해야할 것 같다면 더 좋은 이름이 있을지 궁금하네유
<img width="730" alt="image" src="https://user-images.githubusercontent.com/68374234/206223818-5cbed94d-1029-46cd-90b6-f9704965a682.png">

