### PR TITLE
#157 [fix] rule 수정 scoller 문제 해결

### DIFF
--- a/app/src/main/java/hous/release/android/presentation/our_rules/edit_rule/OurRuleEditFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/our_rules/edit_rule/OurRuleEditFragment.kt
@@ -101,7 +101,6 @@ class OurRuleEditFragment :
                 .also { adapter ->
                     binding.rvEditOurRules.run {
                         this.adapter = adapter
-                        itemAnimator = null
                     }
                 }.also { adapter ->
                     itemTouchHelper = ItemTouchHelper(ItemTouchHelperCallback(adapter)).apply {


### PR DESCRIPTION
## 관련 이슈
- closed #이슈넘버

## 작업한 내용
- rules 수정뷰에서 밑에 아이템을 드래그해서 상단으로 올릴 시 스크롤이 안되는 버그 수정

## PR 포인트
- 아니 진짜 이거 때문에 몇시간을 태운거냐 ㅋㅋㅋㅋㅋㅋㅋㅋㅋ
근데 아직도 item 드래그 하고 위로 스크롤하는 부분 정성껏 안올리면 잘 안올라가더라구요..  
다른 프로젝트도 파서 해보기도 하고, 다른 사람 코드보고도 해봤는데  일반 리사이클러뷰에서 `notifyItemMoved(fromPos, toPos)` 하면
아래에서 위로 스크롤 잘되는데  리스트어뎁터에서 `submitList` 하면 뭔가 문제가 이쓰요
그래서, 2차 때 규칙 수정뷰 전반적으로 개편해야할듯... 