### PR TITLE
#168 [fix/feat] 2차 QA 수정, 네트워크 연결 상태 오류 시 인터넷 연결 에러 뷰 띄우기 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,10 @@
             </intent-filter>
         </activity>
         <activity
+            android:name=".presentation.network_error.NetworkErrorActivity"
+            android:exported="false"
+            android:screenOrientation="portrait" />
+        <activity
             android:name=".presentation.withdraw.WithdrawActivity"
             android:exported="false"
             android:screenOrientation="portrait"
@@ -39,9 +43,9 @@
             android:screenOrientation="portrait" />
         <activity
             android:name=".presentation.personality.PersonalityActivity"
-			android:exported="false"
+            android:exported="false"
             android:screenOrientation="portrait" />
-		<activity
+        <activity
             android:name=".presentation.profile.homie.HomieProfileActivity"
             android:exported="false"
             android:screenOrientation="portrait" />
@@ -61,7 +65,7 @@
             android:name=".presentation.profile.edit.ProfileEditActivity"
             android:exported="false"
             android:screenOrientation="portrait"
-            android:windowSoftInputMode="adjustResize"/>
+            android:windowSoftInputMode="adjustResize" />
         <activity
             android:name=".presentation.notification.NotificationActivity"
             android:exported="false"
@@ -104,8 +108,7 @@
         <activity
             android:name=".presentation.main.MainActivity"
             android:exported="false"
-            android:screenOrientation="portrait">
-        </activity>
+            android:screenOrientation="portrait"></activity>
         <activity
             android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
             android:exported="true"

--- a/app/src/main/java/hous/release/android/di/RetrofitModule.kt
+++ b/app/src/main/java/hous/release/android/di/RetrofitModule.kt
@@ -3,6 +3,8 @@ package hous.release.android.di
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
+import android.os.Handler
+import android.os.Looper
 import com.google.gson.GsonBuilder
 import dagger.Module
 import dagger.Provides
@@ -90,9 +92,13 @@ object RetrofitModule {
                                                 clear()
                                                 commit()
                                             }
-                                            ToastMessageUtil.showToast(
-                                                context,
-                                                context.getString(R.string.refresh_error)
+                                            Handler(Looper.getMainLooper()).post(
+                                                Runnable {
+                                                    ToastMessageUtil.showToast(
+                                                        context,
+                                                        context.getString(R.string.refresh_error)
+                                                    )
+                                                }
                                             )
                                             context.startActivity(
                                                 Intent(context, LoginActivity::class.java).apply {

--- a/app/src/main/java/hous/release/android/di/RetrofitModule.kt
+++ b/app/src/main/java/hous/release/android/di/RetrofitModule.kt
@@ -3,6 +3,8 @@ package hous.release.android.di
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.os.Handler
 import android.os.Looper
 import com.google.gson.GsonBuilder
@@ -14,6 +16,7 @@ import dagger.hilt.components.SingletonComponent
 import hous.release.android.BuildConfig
 import hous.release.android.R
 import hous.release.android.presentation.login.LoginActivity
+import hous.release.android.presentation.network_error.NetworkErrorActivity
 import hous.release.android.util.ToastMessageUtil
 import hous.release.data.datasource.LocalPrefTokenDataSource
 import hous.release.data.repository.RefreshRepositoryImpl.Companion.EXPIRED_REFRESH_TOKEN
@@ -22,6 +25,7 @@ import hous.release.domain.repository.RefreshRepository
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
+import okhttp3.Response
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.HttpException
 import retrofit2.Retrofit
@@ -39,6 +43,7 @@ object RetrofitModule {
     private const val HEADER_VERSION = "HousVersion"
     private const val OS_TYPE = "AOS"
     private const val BEARER = "Bearer "
+    private const val NETWORK_ERROR = 500
 
     @Qualifier
     @Retention(AnnotationRetention.BINARY)
@@ -52,8 +57,28 @@ object RetrofitModule {
         localPref: SharedPreferences,
         refreshRepository: RefreshRepository,
         localPrefTokenDataSource: LocalPrefTokenDataSource
-    ): Interceptor =
-        Interceptor { chain ->
+    ): Interceptor = object : Interceptor {
+        fun isNetworkConnected(): Boolean {
+            var isConnected = false
+            val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+            val capabilities = cm.getNetworkCapabilities(cm.activeNetwork)
+            if (capabilities != null) {
+                isConnected =
+                    capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) || capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)
+            }
+            return isConnected
+        }
+
+        override fun intercept(chain: Interceptor.Chain): Response {
+            if (!isNetworkConnected()) {
+                context.startActivity(
+                    Intent(
+                        context, NetworkErrorActivity::class.java
+                    ).apply {
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                    }
+                )
+            }
             val request = chain.request()
             var response = chain.proceed(
                 request
@@ -67,6 +92,7 @@ object RetrofitModule {
                     .build()
             )
             when (response.code) {
+                NETWORK_ERROR -> context.startActivity(Intent(context, NetworkErrorActivity::class.java))
                 EXPIRED_TOKEN -> {
                     runBlocking {
                         refreshRepository.refreshHousToken()
@@ -94,15 +120,12 @@ object RetrofitModule {
                                             }
                                             Handler(Looper.getMainLooper()).post(
                                                 Runnable {
-                                                    ToastMessageUtil.showToast(
-                                                        context,
-                                                        context.getString(R.string.refresh_error)
+                                                    ToastMessageUtil.showToast(context, context.getString(R.string.refresh_error))
+                                                    context.startActivity(
+                                                        Intent(context, LoginActivity::class.java).apply {
+                                                            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                                                        }
                                                     )
-                                                }
-                                            )
-                                            context.startActivity(
-                                                Intent(context, LoginActivity::class.java).apply {
-                                                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
                                                 }
                                             )
                                         }
@@ -112,13 +135,14 @@ object RetrofitModule {
                     }
                 }
             }
-            response
+            return response
         }
+    }
 
     @Provides
     @Singleton
-    @NormalType
-    fun providesOkHttpClient(@NormalType interceptor: Interceptor): OkHttpClient =
+    @RetrofitModule.NormalType
+    fun providesOkHttpClient(@RetrofitModule.NormalType interceptor: Interceptor): OkHttpClient =
         OkHttpClient.Builder()
             .connectTimeout(10, TimeUnit.SECONDS)
             .writeTimeout(10, TimeUnit.SECONDS)

--- a/app/src/main/java/hous/release/android/presentation/enter_room/EnterRoomActivity.kt
+++ b/app/src/main/java/hous/release/android/presentation/enter_room/EnterRoomActivity.kt
@@ -1,9 +1,40 @@
 package hous.release.android.presentation.enter_room
 
+import android.os.Bundle
+import androidx.activity.addCallback
 import dagger.hilt.android.AndroidEntryPoint
 import hous.release.android.R
 import hous.release.android.databinding.ActivityEnterRoomBinding
+import hous.release.android.util.ToastMessageUtil
 import hous.release.android.util.binding.BindingActivity
+import kotlin.system.exitProcess
 
 @AndroidEntryPoint
-class EnterRoomActivity : BindingActivity<ActivityEnterRoomBinding>(R.layout.activity_enter_room)
+class EnterRoomActivity : BindingActivity<ActivityEnterRoomBinding>(R.layout.activity_enter_room) {
+    private var onBackPressedTime = 0L
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        initBackPressedCallback()
+    }
+
+    private fun initBackPressedCallback() {
+        onBackPressedDispatcher.addCallback {
+            if (System.currentTimeMillis() - onBackPressedTime >= WAITING_DEADLINE) {
+                onBackPressedTime = System.currentTimeMillis()
+                ToastMessageUtil.showToast(
+                    this@EnterRoomActivity,
+                    getString(R.string.finish_app_toast_msg)
+                )
+            } else {
+                finishAffinity()
+                System.runFinalization()
+                exitProcess(0)
+            }
+        }
+    }
+
+    companion object {
+        private const val WAITING_DEADLINE = 2000L
+    }
+}

--- a/app/src/main/java/hous/release/android/presentation/enter_room/create_room/CreateRoomDialogFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/enter_room/create_room/CreateRoomDialogFragment.kt
@@ -34,6 +34,7 @@ class CreateRoomDialogFragment : DialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        isCancelable = false
         initLayout()
         initInviteBtnClickListener()
         initCloseClickListener()

--- a/app/src/main/java/hous/release/android/presentation/enter_room/enter_room_code/EnterRoomCodeDialogFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/enter_room/enter_room_code/EnterRoomCodeDialogFragment.kt
@@ -38,6 +38,7 @@ class EnterRoomCodeDialogFragment : DialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        isCancelable = false
         binding.viewModel = viewModel
         initLayout()
         initEnterRoomUiEventCollector()

--- a/app/src/main/java/hous/release/android/presentation/enter_room/enter_room_code/EnterRoomCodeViewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/enter_room/enter_room_code/EnterRoomCodeViewModel.kt
@@ -40,6 +40,7 @@ class EnterRoomCodeViewModel @Inject constructor(
 
     fun resetRoomCode() {
         roomCode.value = ""
+        _roomInfo.value = Room()
     }
 
     fun getEnterRoomCode() {

--- a/app/src/main/java/hous/release/android/presentation/network_error/NetworkErrorActivity.kt
+++ b/app/src/main/java/hous/release/android/presentation/network_error/NetworkErrorActivity.kt
@@ -1,22 +1,50 @@
 package hous.release.android.presentation.network_error
 
+import android.app.Activity
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import dagger.hilt.android.AndroidEntryPoint
 import hous.release.android.R
 import hous.release.android.databinding.ActivityNetworkErrorBinding
+import hous.release.android.presentation.enter_room.EnterRoomActivity
+import hous.release.android.presentation.login.LoginActivity
 import hous.release.android.presentation.main.MainActivity
+import hous.release.android.presentation.tutorial.TutorialActivity
 import hous.release.android.util.binding.BindingActivity
+import hous.release.domain.entity.SplashState
+import hous.release.domain.usecase.GetSplashStateUseCase
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class NetworkErrorActivity :
     BindingActivity<ActivityNetworkErrorBinding>(R.layout.activity_network_error) {
+    @Inject
+    lateinit var getSplashStateUseCase: GetSplashStateUseCase
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        checkNetworkConnect()
+    }
 
+    fun checkNetworkConnect() {
         binding.btnNetworkErrorRetry.setOnClickListener {
+            when (getSplashStateUseCase()) {
+                SplashState.TUTORIAL -> startActivity<TutorialActivity>()
+                SplashState.LOGIN -> startActivity<LoginActivity>()
+                SplashState.ENTER_ROOM -> startActivity<EnterRoomActivity>()
+                SplashState.MAIN -> startActivity<MainActivity>()
+            }
+            overridePendingTransition(0, 0)
             finish()
-            startActivity(Intent(this, MainActivity::class.java).apply {
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
-            })
         }
+    }
+
+    inline fun <reified T : Activity> Context.startActivity(block: Intent.() -> Unit = {}) {
+        startActivity(
+            Intent(this, T::class.java).apply(block).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            }
+        )
     }
 }

--- a/app/src/main/java/hous/release/android/presentation/network_error/NetworkErrorActivity.kt
+++ b/app/src/main/java/hous/release/android/presentation/network_error/NetworkErrorActivity.kt
@@ -1,0 +1,22 @@
+package hous.release.android.presentation.network_error
+
+import android.content.Intent
+import android.os.Bundle
+import hous.release.android.R
+import hous.release.android.databinding.ActivityNetworkErrorBinding
+import hous.release.android.presentation.main.MainActivity
+import hous.release.android.util.binding.BindingActivity
+
+class NetworkErrorActivity :
+    BindingActivity<ActivityNetworkErrorBinding>(R.layout.activity_network_error) {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        binding.btnNetworkErrorRetry.setOnClickListener {
+            finish()
+            startActivity(Intent(this, MainActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            })
+        }
+    }
+}

--- a/app/src/main/java/hous/release/android/presentation/network_error/NetworkErrorActivity.kt
+++ b/app/src/main/java/hous/release/android/presentation/network_error/NetworkErrorActivity.kt
@@ -11,7 +11,9 @@ import hous.release.android.presentation.enter_room.EnterRoomActivity
 import hous.release.android.presentation.login.LoginActivity
 import hous.release.android.presentation.main.MainActivity
 import hous.release.android.presentation.tutorial.TutorialActivity
+import hous.release.android.util.ToastMessageUtil
 import hous.release.android.util.binding.BindingActivity
+import hous.release.android.util.extension.isNetworkConnected
 import hous.release.domain.entity.SplashState
 import hous.release.domain.usecase.GetSplashStateUseCase
 import javax.inject.Inject
@@ -27,16 +29,20 @@ class NetworkErrorActivity :
         checkNetworkConnect()
     }
 
-    fun checkNetworkConnect() {
+    private fun checkNetworkConnect() {
         binding.btnNetworkErrorRetry.setOnClickListener {
-            when (getSplashStateUseCase()) {
-                SplashState.TUTORIAL -> startActivity<TutorialActivity>()
-                SplashState.LOGIN -> startActivity<LoginActivity>()
-                SplashState.ENTER_ROOM -> startActivity<EnterRoomActivity>()
-                SplashState.MAIN -> startActivity<MainActivity>()
+            if (isNetworkConnected()) {
+                when (getSplashStateUseCase()) {
+                    SplashState.TUTORIAL -> startActivity<TutorialActivity>()
+                    SplashState.LOGIN -> startActivity<LoginActivity>()
+                    SplashState.ENTER_ROOM -> startActivity<EnterRoomActivity>()
+                    SplashState.MAIN -> startActivity<MainActivity>()
+                }
+                overridePendingTransition(0, 0)
+                finish()
+            } else {
+                ToastMessageUtil.showToast(this@NetworkErrorActivity, getString(R.string.network_error_toast))
             }
-            overridePendingTransition(0, 0)
-            finish()
         }
     }
 

--- a/app/src/main/java/hous/release/android/presentation/settings/SettingsActivity.kt
+++ b/app/src/main/java/hous/release/android/presentation/settings/SettingsActivity.kt
@@ -46,13 +46,13 @@ class SettingsActivity : BindingActivity<ActivitySettingsBinding>(R.layout.activ
     }
 
     private fun initNotiSettingClickListener() {
-        binding.btnSettingsNotification.setOnClickListener {
+        binding.tvSettingsNotification.setOnClickListener {
             startActivity(Intent(this, NotificationSettingsActivity::class.java))
         }
     }
 
     private fun initInfoClickListener() {
-        binding.btnSettingsInfo.setOnClickListener {
+        binding.tvSettingsInfo.setOnClickListener {
             startActivity(
                 Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.settings_info_link)))
             )
@@ -60,7 +60,7 @@ class SettingsActivity : BindingActivity<ActivitySettingsBinding>(R.layout.activ
     }
 
     private fun initFeedbackClickListener() {
-        binding.btnSettingsFeedback.setOnClickListener {
+        binding.tvSettingsFeedback.setOnClickListener {
             startActivity(
                 Intent(Intent.ACTION_SEND).apply {
                     type = "plain/text"

--- a/app/src/main/java/hous/release/android/presentation/splash/IntroActivity.kt
+++ b/app/src/main/java/hous/release/android/presentation/splash/IntroActivity.kt
@@ -1,10 +1,10 @@
 package hous.release.android.presentation.splash
 
+import android.animation.Animator
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import hous.release.android.R
 import hous.release.android.databinding.ActivityIntroBinding
@@ -16,8 +16,6 @@ import hous.release.android.util.binding.BindingActivity
 import hous.release.domain.entity.SplashState
 import hous.release.domain.usecase.GetSplashStateUseCase
 import javax.inject.Inject
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class IntroActivity : BindingActivity<ActivityIntroBinding>(R.layout.activity_intro) {
@@ -27,17 +25,22 @@ class IntroActivity : BindingActivity<ActivityIntroBinding>(R.layout.activity_in
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding.lottieSplashImg.playAnimation()
-        lifecycleScope.launch {
-            delay(3000)
-            when (getSplashStateUseCase()) {
-                SplashState.TUTORIAL -> startActivity<TutorialActivity>()
-                SplashState.LOGIN -> startActivity<LoginActivity>()
-                SplashState.ENTER_ROOM -> startActivity<EnterRoomActivity>()
-                SplashState.MAIN -> startActivity<MainActivity>()
+        binding.lottieSplashImg.addAnimatorListener(object : Animator.AnimatorListener {
+            override fun onAnimationEnd(animation: Animator?) {
+                when (getSplashStateUseCase()) {
+                    SplashState.TUTORIAL -> startActivity<TutorialActivity>()
+                    SplashState.LOGIN -> startActivity<LoginActivity>()
+                    SplashState.ENTER_ROOM -> startActivity<EnterRoomActivity>()
+                    SplashState.MAIN -> startActivity<MainActivity>()
+                }
+                overridePendingTransition(0, 0)
+                finish()
             }
-            overridePendingTransition(0, 0)
-            finish()
-        }
+
+            override fun onAnimationStart(animation: Animator?) {}
+            override fun onAnimationCancel(animation: Animator?) {}
+            override fun onAnimationRepeat(animation: Animator?) {}
+        })
     }
 
     inline fun <reified T : Activity> Context.startActivity(block: Intent.() -> Unit = {}) {

--- a/app/src/main/java/hous/release/android/util/dialog/WarningDialogFragment.kt
+++ b/app/src/main/java/hous/release/android/util/dialog/WarningDialogFragment.kt
@@ -26,6 +26,7 @@ class WarningDialogFragment : DialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        isCancelable = false
         initLayout()
         initWarningDialogContent()
         initCancelClickListener()

--- a/app/src/main/java/hous/release/android/util/extension/ContextExtension.kt
+++ b/app/src/main/java/hous/release/android/util/extension/ContextExtension.kt
@@ -1,0 +1,16 @@
+package hous.release.android.util.extension
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+
+fun Context.isNetworkConnected(): Boolean {
+    var isConnected = false
+    val cm = this.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    val capabilities = cm.getNetworkCapabilities(cm.activeNetwork)
+    if (capabilities != null) {
+        isConnected =
+            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) || capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)
+    }
+    return isConnected
+}

--- a/app/src/main/res/drawable/ic_network_error.xml
+++ b/app/src/main/res/drawable/ic_network_error.xml
@@ -1,0 +1,67 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="240dp"
+    android:height="240dp"
+    android:viewportWidth="240"
+    android:viewportHeight="240">
+  <group>
+    <clip-path
+        android:pathData="M0,0h240v240h-240z"/>
+    <path
+        android:pathData="M164.69,130.07C164.69,130.07 181.2,161.72 197.71,128.9"
+        android:strokeWidth="6.28947"
+        android:fillColor="#00000000"
+        android:strokeColor="#52D150"/>
+    <path
+        android:pathData="M97.07,155.06V217.15H115.19"
+        android:strokeWidth="6.28947"
+        android:fillColor="#00000000"
+        android:strokeColor="#52D150"/>
+    <path
+        android:pathData="M138.96,155.06V217.15H157.08"
+        android:strokeWidth="6.28947"
+        android:fillColor="#00000000"
+        android:strokeColor="#52D150"/>
+    <path
+        android:pathData="M157.76,39.59H82.24L44.48,104.99L82.24,170.39H157.76L195.52,104.99L157.76,39.59Z"
+        android:fillColor="#8FF28D"/>
+    <path
+        android:pathData="M134.3,95.19C136.56,95.19 138.38,93.37 138.38,91.11C138.38,88.86 136.56,87.03 134.3,87.03C132.05,87.03 130.23,88.86 130.23,91.11C130.23,93.37 132.05,95.19 134.3,95.19Z"
+        android:fillColor="#ffffff"/>
+    <path
+        android:pathData="M149.21,100.12C151.46,100.12 153.29,98.3 153.29,96.04C153.29,93.79 151.46,91.96 149.21,91.96C146.96,91.96 145.13,93.79 145.13,96.04C145.13,98.3 146.96,100.12 149.21,100.12Z"
+        android:fillColor="#ffffff"/>
+    <path
+        android:pathData="M158.42,93.25C160.68,93.25 162.5,91.42 162.5,89.17C162.5,86.92 160.68,85.09 158.42,85.09C156.17,85.09 154.34,86.92 154.34,89.17C154.34,91.42 156.17,93.25 158.42,93.25Z"
+        android:fillColor="#ffffff"/>
+    <path
+        android:pathData="M157.15,112.88C157.7,108.16 152.13,103.63 144.7,102.76C137.27,101.89 130.81,105.02 130.26,109.74C129.71,114.46 135.28,118.99 142.7,119.85C150.13,120.72 156.6,117.6 157.15,112.88Z"
+        android:fillColor="#ffffff"/>
+    <path
+        android:pathData="M245.1,217.15C245.1,217.15 225.49,217.71 225.49,195.78C225.49,159.4 211.9,142.37 197.11,130.07"
+        android:strokeWidth="4.78"
+        android:fillColor="#00000000"
+        android:strokeColor="#87C5FF"/>
+    <path
+        android:pathData="M201.81,121.94C205.95,125.2 206.67,131.2 203.41,135.35C200.15,139.49 194.15,140.21 190,136.95L187.34,134.86L199.15,119.85L201.81,121.94Z"
+        android:fillColor="#87C5FF"/>
+    <path
+        android:pathData="M73.74,117.64C73.74,117.64 53.23,137.74 71.8,148.31C86.77,156.82 104.83,128.91 104.83,128.91"
+        android:strokeWidth="6.28947"
+        android:fillColor="#00000000"
+        android:strokeColor="#52D150"/>
+    <path
+        android:pathData="M0,217.15H41.36C41.36,217.15 60.97,217.71 60.97,195.78C60.97,159.4 77.74,137.81 100.53,132.77"
+        android:strokeWidth="4.78"
+        android:fillColor="#00000000"
+        android:strokeColor="#87C5FF"/>
+    <path
+        android:pathData="M111.08,138.39C106.24,140.49 100.62,138.27 98.52,133.43C96.43,128.59 98.65,122.97 103.49,120.87L106.59,119.53L114.18,137.05L111.07,138.39H111.08Z"
+        android:fillColor="#87C5FF"/>
+    <path
+        android:pathData="M113.02,123.17L112.72,122.47C112.42,121.78 111.61,121.47 110.92,121.76L106.31,123.76C105.62,124.06 105.3,124.87 105.6,125.56L105.9,126.25C106.2,126.94 107,127.26 107.69,126.96L112.31,124.96C113,124.66 113.32,123.86 113.02,123.17Z"
+        android:fillColor="#87C5FF"/>
+    <path
+        android:pathData="M116.22,130.56L115.92,129.87C115.62,129.17 114.82,128.86 114.13,129.15L109.51,131.15C108.82,131.45 108.5,132.26 108.8,132.95L109.1,133.64C109.4,134.33 110.2,134.65 110.89,134.35L115.51,132.35C116.2,132.05 116.52,131.25 116.22,130.56Z"
+        android:fillColor="#87C5FF"/>
+  </group>
+</vector>

--- a/app/src/main/res/layout/activity_network_error.xml
+++ b/app/src/main/res/layout/activity_network_error.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".presentation.network_error.NetworkErrorActivity">
+
+        <Button
+            android:id="@+id/btn_network_error_retry"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="다시시도"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/activity_network_error.xml
+++ b/app/src/main/res/layout/activity_network_error.xml
@@ -10,14 +10,73 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@color/hous_white"
         tools:context=".presentation.network_error.NetworkErrorActivity">
 
-        <Button
-            android:id="@+id/btn_network_error_retry"
-            android:layout_width="match_parent"
+        <ImageView
+            android:id="@+id/iv_network_error"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="다시시도"
-            app:layout_constraintTop_toTopOf="parent" />
+            android:contentDescription="@string/network_error_img_desc"
+            android:src="@drawable/ic_network_error"
+            app:layout_constraintBottom_toTopOf="@id/tv_network_error_title"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.45"
+            app:layout_constraintVertical_chainStyle="packed" />
+
+        <TextView
+            android:id="@+id/tv_network_error_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="20dp"
+            android:gravity="center_horizontal"
+            android:text="@string/network_error_title"
+            android:textColor="@color/hous_black"
+            android:theme="@style/H3"
+            app:layout_constraintBottom_toTopOf="@id/tv_network_error_desc"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/iv_network_error" />
+
+        <TextView
+            android:id="@+id/tv_network_error_desc"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="12dp"
+            android:gravity="center_horizontal"
+            android:text="@string/network_error_desc"
+            android:textColor="@color/hous_g_5"
+            android:theme="@style/B2"
+            app:layout_constraintBottom_toTopOf="@id/btn_network_error_retry"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_network_error_title" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_network_error_retry"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="40dp"
+            android:layout_marginBottom="20dp"
+            android:insetTop="0dp"
+            android:insetBottom="0dp"
+            android:minHeight="0dp"
+            android:paddingHorizontal="44dp"
+            android:paddingVertical="10dp"
+            android:stateListAnimator="@null"
+            android:text="@string/network_error_retry"
+            android:textColor="@color/hous_white"
+            android:theme="@style/B1"
+            app:cornerRadius="8dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_network_error_desc" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/activity_out_room.xml
+++ b/app/src/main/res/layout/activity_out_room.xml
@@ -35,8 +35,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/out_room_title"
-            android:textAppearance="@style/B1"
             android:textColor="@color/hous_black"
+            android:theme="@style/B1"
             app:layout_constraintBottom_toBottomOf="@id/btn_out_room_back"
             app:layout_constraintStart_toEndOf="@id/btn_out_room_back"
             app:layout_constraintTop_toTopOf="@id/btn_out_room_back" />
@@ -78,8 +78,8 @@
                     android:layout_marginTop="32dp"
                     android:gravity="center_horizontal"
                     android:text="@string/out_room_bye_title"
-                    android:textAppearance="@style/H4"
                     android:textColor="@color/hous_black"
+                    android:theme="@style/H4"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/iv_out_room_graphic" />
@@ -101,14 +101,14 @@
                     android:id="@+id/tv_out_room_bye_caution"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_marginHorizontal="42dp"
+                    android:layout_marginHorizontal="20dp"
                     android:layout_marginTop="34dp"
                     android:gravity="center_horizontal"
                     android:text="@string/out_room_bye_caution"
-                    android:textAppearance="@style/B2"
                     android:textColor="@color/hous_red"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
+                    android:theme="@style/B2"
+                    app:layout_constraintEnd_toEndOf="@id/view_out_room_bye_caution"
+                    app:layout_constraintStart_toStartOf="@id/view_out_room_bye_caution"
                     app:layout_constraintTop_toBottomOf="@id/tv_out_room_bye_title" />
 
                 <TextView
@@ -119,8 +119,8 @@
                     android:layout_marginTop="12dp"
                     android:gravity="center_horizontal"
                     android:text="@string/room_out_bye_desc"
-                    android:textAppearance="@style/B3"
                     android:textColor="@color/hous_g_5"
+                    android:theme="@style/B3"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/view_out_room_bye_caution" />
@@ -141,8 +141,8 @@
                     android:layout_marginStart="18dp"
                     android:layout_marginTop="24dp"
                     android:text="@string/out_room_to_do_prefix"
-                    android:textAppearance="@style/B1"
                     android:textColor="@color/hous_g_5"
+                    android:theme="@style/B1"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/view_out_room_middle" />
 
@@ -151,8 +151,8 @@
                     myTodoCnt="@{vm.myToDoCnt}"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:textAppearance="@style/H3"
                     android:textColor="@color/hous_blue"
+                    android:theme="@style/H3"
                     app:layout_constraintBottom_toBottomOf="@id/tv_out_room_to_room_prefix"
                     app:layout_constraintStart_toEndOf="@id/tv_out_room_to_room_prefix"
                     app:layout_constraintTop_toTopOf="@id/tv_out_room_to_room_prefix" />
@@ -162,8 +162,8 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/out_room_to_do_suffix"
-                    android:textAppearance="@style/B1"
                     android:textColor="@color/hous_g_5"
+                    android:theme="@style/B1"
                     app:layout_constraintStart_toEndOf="@id/tv_out_room_to_room_count"
                     app:layout_constraintTop_toTopOf="@id/tv_out_room_to_room_prefix" />
 
@@ -174,8 +174,8 @@
                     android:layout_marginStart="18dp"
                     android:layout_marginTop="16dp"
                     android:text="@string/hous_my_todo"
-                    android:textAppearance="@style/Emt2"
                     android:textColor="@color/hous_black"
+                    android:theme="@style/Emt2"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_out_room_to_room_prefix" />
 
@@ -187,8 +187,8 @@
                     android:layout_marginTop="40dp"
                     android:gravity="center_horizontal"
                     android:text="@string/out_room_to_do_empty"
-                    android:textAppearance="@style/B3"
                     android:textColor="@color/hous_g_5"
+                    android:theme="@style/B3"
                     android:visibility="@{vm.myToDoCnt == 0 ? View.VISIBLE : View.GONE}"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
@@ -235,8 +235,8 @@
             android:paddingVertical="10dp"
             android:stateListAnimator="@null"
             android:text="@string/out_room_title"
-            android:textAppearance="@style/B1"
             android:textColor="@color/hous_white"
+            android:theme="@style/B1"
             app:cornerRadius="8dp"
             app:layout_constraintBottom_toBottomOf="parent" />
 

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -49,123 +49,63 @@
             android:background="@color/hous_g_line"
             app:layout_constraintTop_toBottomOf="@id/btn_settings_back" />
 
-        <ImageView
-            android:id="@+id/iv_settings_notification"
-            android:layout_width="wrap_content"
+
+        <TextView
+            android:id="@+id/tv_settings_notification"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="20dp"
-            android:contentDescription="@string/settings_notification"
-            android:src="@drawable/ic_alarm"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="12dp"
+            android:drawablePadding="12dp"
+            android:paddingVertical="8dp"
+            android:text="@string/settings_notification"
+            android:textColor="@color/hous_black"
+            android:theme="@style/B1"
+            app:drawableEndCompat="@drawable/ic_settings_next"
+            app:drawableStartCompat="@drawable/ic_alarm"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/view_settings_top" />
 
         <TextView
-            android:id="@+id/tv_settings_notification"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="12dp"
-            android:text="@string/settings_notification"
-            android:textColor="@color/hous_black"
-            android:theme="@style/B1"
-            app:layout_constraintBottom_toBottomOf="@id/iv_settings_notification"
-            app:layout_constraintEnd_toStartOf="@id/btn_settings_notification"
-            app:layout_constraintStart_toEndOf="@id/iv_settings_notification"
-            app:layout_constraintTop_toTopOf="@id/iv_settings_notification" />
-
-        <ImageButton
-            android:id="@+id/btn_settings_notification"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="12dp"
-            android:background="@null"
-            android:contentDescription="@string/settings_notification"
-            android:padding="8dp"
-            android:src="@drawable/ic_settings_next"
-            app:layout_constraintBottom_toBottomOf="@id/iv_settings_notification"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@id/iv_settings_notification" />
-
-        <ImageView
-            android:id="@+id/iv_settings_info"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="24dp"
-            android:contentDescription="@string/settings_info"
-            android:src="@drawable/ic_info"
-            app:layout_constraintStart_toStartOf="@id/iv_settings_notification"
-            app:layout_constraintTop_toBottomOf="@id/iv_settings_notification" />
-
-        <TextView
             android:id="@+id/tv_settings_info"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="12dp"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="8dp"
+            android:drawablePadding="12dp"
+            android:paddingVertical="8dp"
             android:text="@string/settings_info"
             android:textColor="@color/hous_black"
             android:theme="@style/B1"
-            app:layout_constraintBottom_toBottomOf="@id/iv_settings_info"
-            app:layout_constraintEnd_toStartOf="@id/btn_settings_info"
-            app:layout_constraintStart_toEndOf="@id/iv_settings_info"
-            app:layout_constraintTop_toTopOf="@id/iv_settings_info" />
-
-        <ImageButton
-            android:id="@+id/btn_settings_info"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="12dp"
-            android:background="@null"
-            android:contentDescription="@string/settings_info"
-            android:padding="8dp"
-            android:src="@drawable/ic_settings_next"
-            app:layout_constraintBottom_toBottomOf="@id/iv_settings_info"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@id/iv_settings_info" />
-
-        <ImageView
-            android:id="@+id/iv_settings_feedback"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="24dp"
-            android:contentDescription="@string/settings_feedback"
-            android:src="@drawable/ic_feedback"
-            app:layout_constraintStart_toStartOf="@id/iv_settings_notification"
-            app:layout_constraintTop_toBottomOf="@id/iv_settings_info" />
+            app:drawableEndCompat="@drawable/ic_settings_next"
+            app:drawableStartCompat="@drawable/ic_info"
+            app:layout_constraintStart_toStartOf="@id/tv_settings_notification"
+            app:layout_constraintTop_toBottomOf="@id/tv_settings_notification" />
 
         <TextView
             android:id="@+id/tv_settings_feedback"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="12dp"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="8dp"
+            android:drawablePadding="12dp"
+            android:paddingVertical="8dp"
             android:text="@string/settings_feedback"
             android:textColor="@color/hous_black"
             android:theme="@style/B1"
-            app:layout_constraintBottom_toBottomOf="@id/iv_settings_feedback"
-            app:layout_constraintEnd_toStartOf="@id/btn_settings_feedback"
-            app:layout_constraintStart_toEndOf="@id/iv_settings_feedback"
-            app:layout_constraintTop_toTopOf="@id/iv_settings_feedback" />
-
-        <ImageButton
-            android:id="@+id/btn_settings_feedback"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="12dp"
-            android:background="@null"
-            android:contentDescription="@string/settings_feedback"
-            android:padding="8dp"
-            android:src="@drawable/ic_settings_next"
-            app:layout_constraintBottom_toBottomOf="@id/iv_settings_feedback"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@id/iv_settings_feedback" />
+            app:drawableEndCompat="@drawable/ic_settings_next"
+            app:drawableStartCompat="@drawable/ic_feedback"
+            app:layout_constraintStart_toStartOf="@id/tv_settings_notification"
+            app:layout_constraintTop_toBottomOf="@id/tv_settings_info" />
 
         <View
             android:id="@+id/view_settings_bottom"
             android:layout_width="match_parent"
             android:layout_height="1dp"
             android:layout_marginHorizontal="16dp"
-            android:layout_marginTop="24dp"
+            android:layout_marginTop="16dp"
             android:background="@color/hous_g_line"
-            app:layout_constraintTop_toBottomOf="@id/iv_settings_feedback" />
+            app:layout_constraintTop_toBottomOf="@id/tv_settings_feedback" />
 
         <TextView
             android:id="@+id/tv_settings_logout"

--- a/app/src/main/res/layout/activity_withdraw.xml
+++ b/app/src/main/res/layout/activity_withdraw.xml
@@ -154,7 +154,7 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="18dp"
-                    android:layout_marginTop="16dp"
+                    android:layout_marginTop="24dp"
                     android:background="@null"
                     android:fontFamily="@font/spoqa_han_sans_neo_regular"
                     android:hint="@string/withdraw_comment_hint"

--- a/app/src/main/res/layout/fragment_hous.xml
+++ b/app/src/main/res/layout/fragment_hous.xml
@@ -153,8 +153,8 @@
 
                 <View
                     android:id="@+id/view_hous_my_todo_1"
-                    android:layout_width="3dp"
-                    android:layout_height="3dp"
+                    android:layout_width="5dp"
+                    android:layout_height="5dp"
                     android:layout_marginTop="14dp"
                     android:background="@drawable/shape_blue_fill_oval"
                     android:visibility="@{vm.hous.myTodosCnt >= 1 ? View.VISIBLE : View.INVISIBLE}"
@@ -179,8 +179,8 @@
 
                 <View
                     android:id="@+id/view_hous_my_todo_2"
-                    android:layout_width="3dp"
-                    android:layout_height="3dp"
+                    android:layout_width="5dp"
+                    android:layout_height="5dp"
                     android:layout_marginTop="20dp"
                     android:background="@drawable/shape_blue_fill_oval"
                     android:visibility="@{vm.hous.myTodosCnt >= 2 ? View.VISIBLE : View.INVISIBLE}"
@@ -205,8 +205,8 @@
 
                 <View
                     android:id="@+id/view_hous_my_todo_3"
-                    android:layout_width="3dp"
-                    android:layout_height="3dp"
+                    android:layout_width="5dp"
+                    android:layout_height="5dp"
                     android:layout_marginTop="20dp"
                     android:background="@drawable/shape_blue_fill_oval"
                     android:visibility="@{vm.hous.myTodosCnt >= 3 ? View.VISIBLE : View.INVISIBLE}"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -364,9 +364,12 @@
     <string name="withdraw_done">회원 탈퇴하기</string>
     <string name="withdraw_spinner_img_desc">피드백 스피너 이미지</string>
     <string name="withdraw_toast">탈퇴되었습니다.</string>
+
+    <!-- NetworkError -->
     <string name="network_error_img_desc">네트워크 에러 이미지</string>
     <string name="network_error_title">인터넷에 연결되어 있지 않아요!</string>
     <string name="network_error_desc">Hous-를 사용하려면 인터넷 연결이 필요해요.\nWi-Fi를 다시 한 번 확인해주세요!</string>
     <string name="network_error_retry">다시 시도하기</string>
+    <string name="network_error_toast">인터넷 연결 후 다시 시도해 주세요.</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -364,5 +364,9 @@
     <string name="withdraw_done">회원 탈퇴하기</string>
     <string name="withdraw_spinner_img_desc">피드백 스피너 이미지</string>
     <string name="withdraw_toast">탈퇴되었습니다.</string>
+    <string name="network_error_img_desc">네트워크 에러 이미지</string>
+    <string name="network_error_title">인터넷에 연결되어 있지 않아요!</string>
+    <string name="network_error_desc">Hous-를 사용하려면 인터넷 연결이 필요해요.\nWi-Fi를 다시 한 번 확인해주세요!</string>
+    <string name="network_error_retry">다시 시도하기</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -341,8 +341,8 @@
     <string name="out_room_title">방 퇴사하기</string>
     <string name="out_room_img_desc">방 퇴사하기 그래픽</string>
     <string name="out_room_bye_title">안녕... 정든 우리 Hous-...</string>
-    <string name="out_room_bye_caution">*방을 탈퇴하면 내게만 배정된 to-do가 삭제돼요!</string>
-    <string name="room_out_bye_desc">탈퇴 전에 이 페이지를 캡쳐해서 호미들에게 공유하고,\n담당자 교체를 제안하면 어떨까요?</string>
+    <string name="out_room_bye_caution">*방을 퇴사하면 내게만 배정된 to-do가 삭제돼요!</string>
+    <string name="room_out_bye_desc">퇴사 전에 이 페이지를 캡쳐해서 호미들에게 공유하고,\n담당자 교체를 제안하면 어떨까요?</string>
     <string name="out_room_to_do_prefix">총</string>
     <string name="out_room_to_do_suffix">개</string>
     <string name="out_room_blur_bottom_img_desc">방 퇴사하기 하단 블러</string>


### PR DESCRIPTION
## 관련 이슈
- closed #168

## 작업한 내용

-  스레드에서 토스트 메시지 띄울 시 ui(메인)스레드에서 띄울 수 있도록 감싸주기
-  회원가입 이후 방 생성/참여 뷰에서 뒤로가기 앱종료 토스트 띄우기
-  설정 - 알림, 개인정보 및 약관, 호미나라 피드백 보내기 모두 전체 영역 클릭되도록 바꾸기
-  회원탈퇴 - '지금까지 Hous-를 이용해주셔서 감사합니다.' 문구에 Bold 처리
-  회원탈퇴 - <사유 선택하기 아코디언 box>와 <의견 남기기 text 영역> 사이의 간격을 16px에서 24px로 수정
-  방 생성 시 팝업 - 뒤로가기, 외부영역 클릭 시 안닫히도록 하기
-  방 참여 시 팝업 - 뒤로가기, 외부영역 클릭 시 안닫히도록 하기
-  방 코드 입력 시 - 잘못된 코드 입력 후 뒤로가기 이후 다시 돌아왔을 때도 에러문구 띄워져있는 현상 수정
-  방 퇴사하기 - 주의 문구(방을 탈퇴하면~삭제돼요)에서 '삭제돼요!' 부분만 2번째 줄로 내려오는 것 같아요. 1줄로 해주세요!
-  방 퇴사하기 - 탈퇴 전에~어떨까요? 설명 문구 행간 160% 필요.
-  My to-do의 to do 이름 앞에 있는 원( - )의 크기 조정
-  인터넷 연결 상태 오류 시 네트워크 에러 뷰 띄우기
-  인터넷 에러 뷰 - 다시 시도하기 클릭 시 SplashState에 따라 화면 옮기기
-  인터넷 에러 뷰 만들기

## PR 포인트
- 인터넷 연결 에러뷰 구현 부분만 봐주면 될 것 같아요! (RetrofitModule, ContextExtension, NetworkErrorActivity)
