### PR TITLE
#192 [fix] 개강 전 수정사항 반영

### DIFF
--- a/app/src/main/java/hous/release/android/presentation/hous/HousFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/hous/HousFragment.kt
@@ -21,6 +21,7 @@ import hous.release.android.util.HousLogEvent.clickLogEvent
 import hous.release.android.util.ToastMessageUtil
 import hous.release.android.util.binding.BindingFragment
 import hous.release.android.util.extension.repeatOnStarted
+import hous.release.android.util.extension.setSingleOnClickListener
 import hous.release.domain.entity.HomyType
 import hous.release.domain.entity.response.Homy
 
@@ -66,7 +67,7 @@ class HousFragment : BindingFragment<FragmentHousBinding>(R.layout.fragment_hous
     }
 
     private fun initClickListener() {
-        binding.btnHousEdit.setOnClickListener {
+        binding.btnHousEdit.setSingleOnClickListener {
             startActivity(
                 Intent(requireContext(), EditHousNameActivity::class.java).apply {
                     putExtra(ROOM_NAME, viewModel.hous.value.roomName)

--- a/app/src/main/java/hous/release/android/presentation/hous/adapter/HomiesAdapter.kt
+++ b/app/src/main/java/hous/release/android/presentation/hous/adapter/HomiesAdapter.kt
@@ -6,6 +6,7 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import hous.release.android.databinding.ItemHousHomiesBinding
 import hous.release.android.util.ItemDiffCallback
+import hous.release.android.util.extension.setSingleOnClickListener
 import hous.release.domain.entity.response.Homy
 
 class HomiesAdapter(
@@ -18,7 +19,7 @@ class HomiesAdapter(
         fun bind(homy: Homy) {
             binding.homy = homy
             binding.executePendingBindings()
-            binding.clHousProfile.setOnClickListener {
+            binding.clHousProfile.setSingleOnClickListener {
                 onClickHomie(homy, absoluteAdapterPosition)
             }
         }

--- a/app/src/main/java/hous/release/android/presentation/login/UserInputActivity.kt
+++ b/app/src/main/java/hous/release/android/presentation/login/UserInputActivity.kt
@@ -17,6 +17,7 @@ import hous.release.android.util.dialog.DatePickerClickListener
 import hous.release.android.util.dialog.DatePickerDialog
 import hous.release.android.util.dialog.WarningDialogFragment.Companion.CONFIRM_ACTION
 import hous.release.android.util.extension.repeatOnStarted
+import hous.release.android.util.extension.setSingleOnClickListener
 import kotlin.system.exitProcess
 
 @AndroidEntryPoint
@@ -76,7 +77,7 @@ class UserInputActivity : BindingActivity<ActivityUserInputBinding>(R.layout.act
     }
 
     private fun initBirthdayOnClickListener() {
-        binding.etUserInputBirthday.setOnClickListener {
+        binding.etUserInputBirthday.setSingleOnClickListener {
             DatePickerDialog().apply {
                 arguments = Bundle().apply {
                     putParcelable(

--- a/app/src/main/java/hous/release/android/presentation/profile/ProfileFragment.kt
+++ b/app/src/main/java/hous/release/android/presentation/profile/ProfileFragment.kt
@@ -24,6 +24,7 @@ import hous.release.android.util.HousLogEvent.clickDateLogEvent
 import hous.release.android.util.HousLogEvent.clickLogEvent
 import hous.release.android.util.binding.BindingFragment
 import hous.release.android.util.extension.repeatOnStarted
+import hous.release.android.util.extension.setSingleOnClickListener
 import hous.release.domain.entity.PersonalityInfo
 
 @AndroidEntryPoint
@@ -73,13 +74,13 @@ class ProfileFragment : BindingFragment<FragmentProfileBinding>(R.layout.fragmen
     }
 
     private fun initNotificationOnClickListener() {
-        binding.btnProfileNotification.setOnClickListener {
+        binding.btnProfileNotification.setSingleOnClickListener {
             startActivity(Intent(requireContext(), NotificationActivity::class.java))
         }
     }
 
     private fun initPersonalityOnClickListener() {
-        binding.llProfilePersonalityDetail.setOnClickListener {
+        binding.llProfilePersonalityDetail.setSingleOnClickListener {
             clickDateLogEvent(CLICK_MY_PERSONALITY)
             startActivity(
                 Intent(requireActivity(), PersonalityResultActivity::class.java).apply {
@@ -94,7 +95,7 @@ class ProfileFragment : BindingFragment<FragmentProfileBinding>(R.layout.fragmen
     }
 
     private fun initSettingOnClickListener() {
-        binding.btnProfileSetting.setOnClickListener {
+        binding.btnProfileSetting.setSingleOnClickListener {
             startActivity(
                 Intent(requireContext(), SettingsActivity::class.java).apply {
                     putExtra(SettingsActivity.HAS_ROOM, true)
@@ -104,17 +105,17 @@ class ProfileFragment : BindingFragment<FragmentProfileBinding>(R.layout.fragmen
     }
 
     private fun initBadgeOnClickListener() {
-        binding.ivProfileBadge.setOnClickListener {
+        binding.ivProfileBadge.setSingleOnClickListener {
             startActivity(Intent(requireContext(), BadgeActivity::class.java))
         }
 
-        binding.tvProfileBadgeEmpty.setOnClickListener {
+        binding.tvProfileBadgeEmpty.setSingleOnClickListener {
             startActivity(Intent(requireContext(), BadgeActivity::class.java))
         }
     }
 
     private fun initEditOnClickListener() {
-        binding.btnProfileEdit.setOnClickListener {
+        binding.btnProfileEdit.setSingleOnClickListener {
             startActivity(
                 Intent(requireContext(), ProfileEditActivity::class.java).apply {
                     with(profileViewModel.uiState.value.profile) {
@@ -141,7 +142,7 @@ class ProfileFragment : BindingFragment<FragmentProfileBinding>(R.layout.fragmen
     }
 
     private fun initTestBtnOnClickListener() {
-        binding.btnProfileTestAgain.setOnClickListener {
+        binding.btnProfileTestAgain.setSingleOnClickListener {
             if (profileViewModel.uiState.value.isTest) clickLogEvent(CLICK_RE_TEST)
             startActivity(Intent(requireContext(), PersonalityActivity::class.java))
         }

--- a/app/src/main/java/hous/release/android/presentation/profile/edit/ProfileEditActivity.kt
+++ b/app/src/main/java/hous/release/android/presentation/profile/edit/ProfileEditActivity.kt
@@ -13,6 +13,7 @@ import hous.release.android.util.dialog.DatePickerClickListener
 import hous.release.android.util.dialog.DatePickerDialog
 import hous.release.android.util.dialog.WarningDialogFragment
 import hous.release.android.util.dialog.WarningType
+import hous.release.android.util.extension.setSingleOnClickListener
 import hous.release.android.util.extension.withArgs
 
 @AndroidEntryPoint
@@ -98,7 +99,7 @@ class ProfileEditActivity :
     }
 
     private fun initBirthdayOnClickListener() {
-        binding.etProfileEditBirthday.setOnClickListener {
+        binding.etProfileEditBirthday.setSingleOnClickListener {
             DatePickerDialog().apply {
                 arguments = Bundle().apply {
                     putParcelable(

--- a/app/src/main/java/hous/release/android/presentation/profile/homie/HomieProfileActivity.kt
+++ b/app/src/main/java/hous/release/android/presentation/profile/homie/HomieProfileActivity.kt
@@ -18,6 +18,7 @@ import hous.release.android.util.HousLogEvent.clickDateLogEvent
 import hous.release.android.util.binding.BindingActivity
 import hous.release.android.util.component.HousPersonalityPentagon
 import hous.release.android.util.extension.repeatOnStarted
+import hous.release.android.util.extension.setSingleOnClickListener
 import hous.release.android.util.style.HousTheme
 
 @AndroidEntryPoint
@@ -47,7 +48,7 @@ class HomieProfileActivity :
     }
 
     private fun initHomiePersonalityOnClickListener() {
-        binding.llHomieProfilePersonalityDetail.setOnClickListener {
+        binding.llHomieProfilePersonalityDetail.setSingleOnClickListener {
             if (intent.getIntExtra(HOMIE_POSITION, DEFAULT) == MY) {
                 clickDateLogEvent(CLICK_MY_PERSONALITY)
             }

--- a/app/src/main/java/hous/release/android/util/dialog/DatePickerDialog.kt
+++ b/app/src/main/java/hous/release/android/util/dialog/DatePickerDialog.kt
@@ -20,6 +20,8 @@ class DatePickerDialog : DialogFragment() {
         _binding = DialogDatePickerBinding.inflate(requireActivity().layoutInflater)
         initConfirmTextClickListener()
         initCancelTextClickListener()
+        initMaxDate()
+        isCancelable = false
         return activity?.let {
             val dialog = MaterialAlertDialogBuilder(
                 requireActivity(),
@@ -33,7 +35,6 @@ class DatePickerDialog : DialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initLayout()
-        initMaxDate()
     }
 
     private fun initMaxDate() {

--- a/app/src/main/java/hous/release/android/util/dialog/DatePickerDialog.kt
+++ b/app/src/main/java/hous/release/android/util/dialog/DatePickerDialog.kt
@@ -1,10 +1,10 @@
 package hous.release.android.util.dialog
 
-import android.app.AlertDialog
 import android.app.Dialog
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.DialogFragment
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import hous.release.android.R
 import hous.release.android.databinding.DialogDatePickerBinding
 import hous.release.android.util.dialog.WarningDialogFragment.Companion.CONFIRM_ACTION
@@ -18,11 +18,10 @@ class DatePickerDialog : DialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         _binding = DialogDatePickerBinding.inflate(requireActivity().layoutInflater)
-        initDatePicker()
         initConfirmTextClickListener()
         initCancelTextClickListener()
         return activity?.let {
-            val dialog = AlertDialog.Builder(it).create()
+            val dialog = MaterialAlertDialogBuilder(requireActivity(), R.style.MaterialAlertDialog_rounded).create()
             dialog.setView(binding.root)
             dialog
         } ?: throw IllegalStateException()
@@ -31,12 +30,6 @@ class DatePickerDialog : DialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initLayout()
-    }
-
-    private fun initDatePicker() {
-        with(binding.datePickerDialogDatePicker) {
-            maxDate = Calendar.getInstance().timeInMillis
-        }
     }
 
     private fun getYearFormat(year: Int): String = year.toString()
@@ -55,6 +48,7 @@ class DatePickerDialog : DialogFragment() {
                 arguments?.getParcelable<DatePickerClickListener>(CONFIRM_ACTION)
                     ?.onConfirmClick(date)
                     ?: Timber.e(getString(R.string.null_point_exception_warning_dialog_argument))
+                updateDate(year, month, dayOfMonth)
             }
             dismiss()
         }

--- a/app/src/main/java/hous/release/android/util/dialog/DatePickerDialog.kt
+++ b/app/src/main/java/hous/release/android/util/dialog/DatePickerDialog.kt
@@ -10,7 +10,6 @@ import hous.release.android.databinding.DialogDatePickerBinding
 import hous.release.android.util.dialog.WarningDialogFragment.Companion.CONFIRM_ACTION
 import hous.release.android.util.extension.initLayout
 import timber.log.Timber
-import java.util.*
 
 class DatePickerDialog : DialogFragment() {
     private var _binding: DialogDatePickerBinding? = null
@@ -21,7 +20,10 @@ class DatePickerDialog : DialogFragment() {
         initConfirmTextClickListener()
         initCancelTextClickListener()
         return activity?.let {
-            val dialog = MaterialAlertDialogBuilder(requireActivity(), R.style.MaterialAlertDialog_rounded).create()
+            val dialog = MaterialAlertDialogBuilder(
+                requireActivity(),
+                R.style.MaterialAlertDialog_rounded
+            ).create()
             dialog.setView(binding.root)
             dialog
         } ?: throw IllegalStateException()

--- a/app/src/main/java/hous/release/android/util/dialog/DatePickerDialog.kt
+++ b/app/src/main/java/hous/release/android/util/dialog/DatePickerDialog.kt
@@ -10,6 +10,7 @@ import hous.release.android.databinding.DialogDatePickerBinding
 import hous.release.android.util.dialog.WarningDialogFragment.Companion.CONFIRM_ACTION
 import hous.release.android.util.extension.initLayout
 import timber.log.Timber
+import java.util.Calendar
 
 class DatePickerDialog : DialogFragment() {
     private var _binding: DialogDatePickerBinding? = null
@@ -32,6 +33,11 @@ class DatePickerDialog : DialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initLayout()
+        initMaxDate()
+    }
+
+    private fun initMaxDate() {
+        binding.datePickerDialogDatePicker.maxDate = Calendar.getInstance().timeInMillis
     }
 
     private fun getYearFormat(year: Int): String = year.toString()

--- a/app/src/main/res/drawable/ic_back_g6.xml
+++ b/app/src/main/res/drawable/ic_back_g6.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#969696"
+        android:pathData="M7.579,12L14,5.579L15.421,7L9,13.421L7.579,12ZM14,18.421L7.579,12L9,10.579L15.421,17L14,18.421Z" />
+</vector>

--- a/app/src/main/res/layout/activity_homie_profile.xml
+++ b/app/src/main/res/layout/activity_homie_profile.xml
@@ -38,7 +38,7 @@
                     android:layout_marginTop="10dp"
                     android:background="@null"
                     android:padding="14dp"
-                    android:src="@drawable/ic_back_g5"
+                    android:src="@drawable/ic_back_g6"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
 

--- a/app/src/main/res/layout/dialog_date_picker.xml
+++ b/app/src/main/res/layout/dialog_date_picker.xml
@@ -26,6 +26,7 @@
         android:layout_marginStart="24dp"
         android:layout_marginTop="24dp"
         android:text="@string/user_input_birthday"
+        android:textColor="@color/hous_black"
         android:theme="@style/H4"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/dialog_date_picker.xml
+++ b/app/src/main/res/layout/dialog_date_picker.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    tools:background="@drawable/shape_white_fill_8_rect">
+    android:background="@drawable/shape_white_fill_8_rect">
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guideline_date_picker_horizental"

--- a/app/src/main/res/layout/dialog_date_picker.xml
+++ b/app/src/main/res/layout/dialog_date_picker.xml
@@ -37,6 +37,7 @@
         android:layout_height="0dp"
         android:calendarViewShown="false"
         android:datePickerMode="spinner"
+        android:descendantFocusability="blocksDescendants"
         android:endYear="2099"
         android:startYear="1900"
         android:theme="@style/PickerTheme"

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -82,6 +82,7 @@
                 android:layout_height="100dp"
                 android:layout_marginTop="12dp"
                 android:layout_marginEnd="43dp"
+                android:background="@drawable/shape_white_fill_100_circle"
                 android:elevation="10dp"
                 android:visibility="@{vm.uiState.profile.representBadgeImage==null ? View.INVISIBLE : View.VISIBLE}"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -29,8 +29,18 @@
         <item name="android:textColor">@color/hous_black</item>
         <item name="android:textStyle">normal</item>
         <item name="android:textSize">20dp</item>
+        <item name="android:windowIsFloating">false</item>
         <item name="android:letterSpacing">-0.02</item>
         <item name="android:lineSpacingExtra">10dp</item>
-        <item name="android:colorControlNormal">@android:color/transparent</item>
+        <item name="android:colorControlNormal">@color/hous_g_5</item>
+    </style>
+
+    <style name="MaterialAlertDialog_rounded" parent="@style/ThemeOverlay.MaterialComponents.Dialog.Alert">
+        <item name="shapeAppearanceOverlay">@style/DialogCorners</item>
+    </style>
+
+    <style name="DialogCorners">
+        <item name="cornerFamily">rounded</item>
+        <item name="cornerSize">8dp</item>
     </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -32,7 +32,7 @@
         <item name="android:windowIsFloating">false</item>
         <item name="android:letterSpacing">-0.02</item>
         <item name="android:lineSpacingExtra">10dp</item>
-        <item name="android:colorControlNormal">@color/hous_g_5</item>
+        <item name="android:colorControlNormal">@android:color/transparent</item>
     </style>
 
     <style name="MaterialAlertDialog_rounded" parent="@style/ThemeOverlay.MaterialComponents.Dialog.Alert">


### PR DESCRIPTION
## 관련 이슈
- closed #192

## 작업한 내용
- 데이트 피커 text 입력 막기
- 데이트 피커 radius style 적용
- 데이트 피커 `isCancelable` 적용
- 호미프로필 뒤로가기 버튼 색상 변경
- 중복클릭 막기 (`setSingleOnClickListener` 설정)
- 내 대표 배지 그림자 설정

## PR 포인트
- 데이트 피커 `isCancelable` 적용 (initLayout에 `isCancelable`이 설정되어있는데 데이트피커에서 안 먹음.. 그래서 `onCreateDialog`에서 재설정 해줬음)
- 데이트 피커 background에 radius가 설정되어있는데 안 먹음.. 그래서 style로 지정해줬음
