### PR TITLE
#220 [refactor] usecase generic으로 수정

### DIFF
--- a/domain/src/main/java/hous/release/domain/usecase/SearchRuleUseCase.kt
+++ b/domain/src/main/java/hous/release/domain/usecase/SearchRuleUseCase.kt
@@ -4,10 +4,10 @@ import hous.release.domain.entity.Rule
 import javax.inject.Inject
 
 class SearchRuleUseCase @Inject constructor() {
-    operator fun invoke(search: String, rules: List<Rule>): List<Rule> {
+    operator fun <T : Rule> invoke(search: String, rules: List<T>): List<T> {
         val clear = search.lowercase().trim()
-        return rules.filter {
-            it.name.lowercase().trim().contains(clear)
+        return rules.filter { rule ->
+            rule.name.lowercase().trim().contains(clear)
         }
     }
 }

--- a/domain/src/test/java/hous/release/domain/usecase/SearchRuleUseCaseTest.kt
+++ b/domain/src/test/java/hous/release/domain/usecase/SearchRuleUseCaseTest.kt
@@ -22,7 +22,7 @@ internal class SearchRuleUseCaseTest {
         val expectList =
             listOf(MainTodo(true, 1, "KWY"), MainTodo(true, 2, "KWY2"), MainTodo(true, 1, "LJW"))
         // when
-        val result: List<MainTodo> = searchUseCase("kw", expectList).filterIsInstance<MainTodo>()
+        val result: List<MainTodo> = searchUseCase("kw", expectList)
         // then
         assertThat(result).isEqualTo(listOf(MainTodo(true, 1, "KWY"), MainTodo(true, 2, "KWY2")))
     }
@@ -37,7 +37,7 @@ internal class SearchRuleUseCaseTest {
             MainTodo(true, 1, "ㄱ ㅏ ㅇ ㅜ ㅓ ㅇ ㅛㅇ   ")
         )
         // when
-        val result: List<MainTodo> = searchUseCase("강  ", expectList).filterIsInstance<MainTodo>()
+        val result: List<MainTodo> = searchUseCase("강  ", expectList)
         // then
         assertThat(result).isEqualTo(listOf(MainTodo(true, 1, "   강원용   ")))
     }


### PR DESCRIPTION
## 관련 이슈
- closed #220 

## 작업한 내용
-  usecase generic으로 수정

## PR 포인트
- 검색을 한 다음에 `filterIsInstance` 을 통해 타입 캐스팅 하는 과정에서 O(n) 의 작업을 다시 하는 것이 아쉬웠습니다.
- `<T :Rule>` 을 통해서 재네릭에 제한을 걸 수 있는 것을 보고 적용해봤습니다.
- 이를 통해서 `filterIsInstance` 를 통해서 타입을 다시 캐스팅하는 작업을 안 해도 됩니다.
