### PR TITLE
#224 [ui] todo detail 바텀시트 구현

### DIFF
--- a/designsystem/src/main/java/hous/release/designsystem/component/HousDetailBottomSheet.kt
+++ b/designsystem/src/main/java/hous/release/designsystem/component/HousDetailBottomSheet.kt
@@ -23,9 +23,10 @@ import hous.release.designsystem.theme.HousTheme
 @Composable
 fun HousDetailBottomSheet(
     modifier: Modifier = Modifier,
+    todoId: Int,
     content: @Composable () -> Unit,
-    editAction: () -> Unit,
-    deleteAction: () -> Unit
+    editAction: (Int) -> Unit,
+    deleteAction: (Int) -> Unit
 ) {
     Column(
         modifier = modifier
@@ -33,6 +34,7 @@ fun HousDetailBottomSheet(
     ) {
         content()
         BottomSheetButton(
+            todoId = todoId,
             text = stringResource(R.string.todo_detail_bs_edit),
             color = HousBlack,
             action = editAction,
@@ -40,6 +42,7 @@ fun HousDetailBottomSheet(
             bottomPadding = 14.dp
         )
         BottomSheetButton(
+            todoId = todoId,
             text = stringResource(R.string.todo_detail_bs_delete),
             color = HousRed,
             action = deleteAction,
@@ -51,17 +54,18 @@ fun HousDetailBottomSheet(
 
 @Composable
 private fun BottomSheetButton(
+    todoId: Int,
     text: String,
     color: Color,
     topPadding: Dp,
     bottomPadding: Dp,
-    action: () -> Unit
+    action: (Int) -> Unit
 ) {
     Divider(modifier = Modifier.height(1.dp))
     Text(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable { action() }
+            .clickable { action(todoId) }
             .padding(top = topPadding, bottom = bottomPadding),
         text = text,
         color = color,

--- a/designsystem/src/main/java/hous/release/designsystem/component/HousDetailBottomSheet.kt
+++ b/designsystem/src/main/java/hous/release/designsystem/component/HousDetailBottomSheet.kt
@@ -1,0 +1,71 @@
+package hous.release.designsystem.component
+
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Divider
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import hous.release.designsystem.R
+import hous.release.designsystem.theme.HousBlack
+import hous.release.designsystem.theme.HousRed
+import hous.release.designsystem.theme.HousTheme
+
+@Composable
+fun HousDetailBottomSheet(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+    editAction: () -> Unit,
+    deleteAction: () -> Unit
+) {
+    Column(
+        modifier = modifier
+            .padding(horizontal = 16.dp)
+    ) {
+        content()
+        BottomSheetButton(
+            text = stringResource(R.string.todo_detail_bs_edit),
+            color = HousBlack,
+            action = editAction,
+            topPadding = 18.dp,
+            bottomPadding = 14.dp
+        )
+        BottomSheetButton(
+            text = stringResource(R.string.todo_detail_bs_delete),
+            color = HousRed,
+            action = deleteAction,
+            topPadding = 18.dp,
+            bottomPadding = 22.dp
+        )
+    }
+}
+
+@Composable
+private fun BottomSheetButton(
+    text: String,
+    color: Color,
+    topPadding: Dp,
+    bottomPadding: Dp,
+    action: () -> Unit
+) {
+    Divider(modifier = Modifier.height(1.dp))
+    Text(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { action() }
+            .padding(top = topPadding, bottom = bottomPadding),
+        text = text,
+        color = color,
+        style = HousTheme.typography.b2,
+        textAlign = TextAlign.Center
+    )
+}

--- a/designsystem/src/main/java/hous/release/designsystem/component/HousDetailBottomSheet.kt
+++ b/designsystem/src/main/java/hous/release/designsystem/component/HousDetailBottomSheet.kt
@@ -1,6 +1,5 @@
 package hous.release.designsystem.component
 
-
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth

--- a/designsystem/src/main/res/values/strings.xml
+++ b/designsystem/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="todo_detail_bs_edit">수정하기</string>
+    <string name="todo_detail_bs_delete">삭제하기</string>
+</resources>

--- a/feature/todo/src/main/java/hous/release/feature/todo/detail/TodoDetailScreen.kt
+++ b/feature/todo/src/main/java/hous/release/feature/todo/detail/TodoDetailScreen.kt
@@ -142,7 +142,12 @@ private fun Todos(
     showToDoDetailBottomSheet: () -> Unit
 ) {
     LazyColumn {
-        items(todos) { todo ->
+        items(
+            items = todos,
+            key = { todo ->
+                todo.id
+            }
+        ) { todo ->
             ToDoItem(
                 todo = todo,
                 showToDoDetailBottomSheet = showToDoDetailBottomSheet

--- a/feature/todo/src/main/java/hous/release/feature/todo/detail/component/TodoDetailBottomSheet.kt
+++ b/feature/todo/src/main/java/hous/release/feature/todo/detail/component/TodoDetailBottomSheet.kt
@@ -1,0 +1,116 @@
+package hous.release.feature.todo.detail.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import hous.release.designsystem.component.HomyChip
+import hous.release.designsystem.component.HousDetailBottomSheet
+import hous.release.designsystem.theme.HousBlack
+import hous.release.designsystem.theme.HousG6
+import hous.release.designsystem.theme.HousTheme
+import hous.release.domain.entity.HomyType
+import hous.release.domain.entity.TodoDetail
+import hous.release.domain.entity.TodoDetail.User
+
+@Composable
+fun TodoDetailBottomSheet(
+    todoId: Int,
+    todoDetail: TodoDetail,
+    editAction: (Int) -> Unit,
+    deleteAction: (Int) -> Unit
+) {
+    HousDetailBottomSheet(
+        todoId = todoId,
+        content = {
+            TodoDetailBottomSheetContent(
+                todo = todoDetail.name,
+                dayOfWeeks = todoDetail.dayOfWeeks,
+                homies = todoDetail.selectedUsers
+            )
+        },
+        editAction = editAction,
+        deleteAction = deleteAction
+    )
+}
+
+@Composable
+private fun TodoDetailBottomSheetContent(
+    todo: String,
+    dayOfWeeks: String,
+    homies: List<User>
+) {
+    Column(
+        modifier = Modifier.padding(top = 24.dp)
+    ) {
+        Text(
+            text = todo,
+            style = HousTheme.typography.b1,
+            color = HousBlack
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = dayOfWeeks,
+            style = HousTheme.typography.b3,
+            color = HousG6
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        SelectedHomies(homies)
+        Spacer(modifier = Modifier.height(20.dp))
+    }
+}
+
+@Composable
+private fun SelectedHomies(
+    homies: List<User>
+) {
+    LazyRow(
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        items(
+            items = homies,
+            key = { homy ->
+                homy.onboardingId
+            }
+        ) { homy ->
+            HomyChip(
+                name = homy.nickname,
+                homyTypeOrdinal = homy.color.ordinal
+            )
+        }
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+private fun TodoDetailBottomSheetPreview() {
+    HousTheme {
+        Box(modifier = Modifier.background(Color.White)) {
+            TodoDetailBottomSheet(
+                todoId = 0,
+                todoDetail = TodoDetail(
+                    name = "청소기 좀 돌려라",
+                    selectedUsers = listOf(
+                        User(onboardingId = 1, nickname = "강원용", color = HomyType.BLUE),
+                        User(onboardingId = 2, nickname = "이영주", color = HomyType.RED),
+                        User(onboardingId = 3, nickname = "이준원", color = HomyType.PURPLE)
+                    ),
+                    dayOfWeeks = "화,수,목,금"
+                ),
+                editAction = {},
+                deleteAction = {}
+            )
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- closed #224 

## 작업한 내용
![image](https://github.com/Hous-Release/hous-AOS/assets/82709044/3a04595e-0d18-4a07-bcfc-a3cd95207c92)

## PR 포인트
- todo detail 바텀시트 만들었습니다.
@murjune 아래 내용 확인해주세요.

| todo 바텀 시트 | rule 바텀 시트 |
| ---------------- | ---------------- |
| ![image](https://github.com/Hous-Release/hous-AOS/assets/82709044/54d2cfa3-4b6b-4690-a6d7-98cdb876933f) | ![image](https://github.com/Hous-Release/hous-AOS/assets/82709044/05a5b11c-bf82-4578-abac-3fce6e1fa75e) |

파란색 동그라미 친 부분이 공통 되어 있길래, 
design system 모듈에 HousDetailBottomSheet 컴포넌트 추가 했습니다.
그래서 rule 바텀시트 작업할 때 `content` 속성에 2개 버튼 위 내용을 추가하시면 됩니다.
예시로 todo detail bottom sheet 참고해서 사용해주세요~