### PR TITLE
#230 [ui, feat] compose dialog 생성

### DIFF
--- a/designsystem/src/main/java/hous/release/designsystem/component/HousDetailBottomSheet.kt
+++ b/designsystem/src/main/java/hous/release/designsystem/component/HousDetailBottomSheet.kt
@@ -22,10 +22,9 @@ import hous.release.designsystem.theme.HousTheme
 @Composable
 fun HousDetailBottomSheet(
     modifier: Modifier = Modifier,
-    todoId: Int,
     content: @Composable () -> Unit,
-    editAction: (Int) -> Unit,
-    deleteAction: (Int) -> Unit
+    editAction: () -> Unit,
+    deleteAction: () -> Unit
 ) {
     Column(
         modifier = modifier
@@ -33,7 +32,6 @@ fun HousDetailBottomSheet(
     ) {
         content()
         BottomSheetButton(
-            todoId = todoId,
             text = stringResource(R.string.todo_detail_bs_edit),
             color = HousBlack,
             action = editAction,
@@ -41,7 +39,6 @@ fun HousDetailBottomSheet(
             bottomPadding = 14.dp
         )
         BottomSheetButton(
-            todoId = todoId,
             text = stringResource(R.string.todo_detail_bs_delete),
             color = HousRed,
             action = deleteAction,
@@ -53,18 +50,17 @@ fun HousDetailBottomSheet(
 
 @Composable
 private fun BottomSheetButton(
-    todoId: Int,
     text: String,
     color: Color,
     topPadding: Dp,
     bottomPadding: Dp,
-    action: (Int) -> Unit
+    action: () -> Unit
 ) {
     Divider(modifier = Modifier.height(1.dp))
     Text(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable { action(todoId) }
+            .clickable { action() }
             .padding(top = topPadding, bottom = bottomPadding),
         text = text,
         color = color,

--- a/designsystem/src/main/java/hous/release/designsystem/component/HousDialog.kt
+++ b/designsystem/src/main/java/hous/release/designsystem/component/HousDialog.kt
@@ -1,0 +1,134 @@
+package hous.release.designsystem.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import hous.release.designsystem.theme.HousBlack
+import hous.release.designsystem.theme.HousG5
+import hous.release.designsystem.theme.HousRed
+import hous.release.designsystem.theme.HousTheme
+
+@Composable
+fun HousDialog(
+    title: String,
+    content: String,
+    neutralText: String,
+    actionText: String,
+    neutralOnClick: () -> Unit,
+    actionOnClick: () -> Unit
+) {
+    HousDialogSlot(
+        title = title,
+        content = content,
+        neutralButton = {
+            Text(
+                modifier = Modifier
+                    .clickable { neutralOnClick() },
+                text = neutralText,
+                style = HousTheme.typography.b2,
+                color = HousG5
+            )
+        },
+        actionButton = {
+            Text(
+                modifier = Modifier
+                    .clickable { actionOnClick() },
+                text = actionText,
+                style = HousTheme.typography.b2,
+                color = HousRed
+            )
+        }
+    )
+}
+
+@Composable
+private fun HousDialogSlot(
+    title: String,
+    content: String,
+    neutralButton: @Composable () -> Unit,
+    actionButton: @Composable () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .padding(
+                top = 24.dp,
+                bottom = 20.dp,
+                start = 24.dp,
+                end = 30.dp
+            )
+    ) {
+        Text(
+            text = title,
+            style = HousTheme.typography.h4,
+            color = HousBlack
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = content,
+            style = HousTheme.typography.description,
+            color = HousG5
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End
+        ) {
+            neutralButton()
+            Spacer(modifier = Modifier.width(32.dp))
+            actionButton()
+        }
+    }
+}
+
+@Preview(
+    showBackground = true,
+    name = "api 연결 없는 다이얼로그"
+)
+@Composable
+private fun HousDialogPreview() {
+    HousTheme {
+        HousDialog(
+            title = "수정사항이 저장되지 않았어요!",
+            content = "정말 취소하려면 나가기 버튼을 눌러주세요.",
+            neutralText = "계속 수정하기",
+            actionText = "나가기",
+            neutralOnClick = { /*TODO*/ },
+            actionOnClick = {}
+        )
+    }
+}
+
+@Preview(
+    showBackground = true,
+    name = "api 연결하는 다이얼로그"
+)
+@Composable
+private fun HousDialogPreview2() {
+    val method: (Int) -> Unit = {}
+    val id = 0
+    HousTheme {
+        HousDialog(
+            title = "수정사항이 저장되지 않았어요!",
+            content = "정말 취소하려면 나가기 버튼을 눌러주세요.",
+            neutralText = "계속 수정하기",
+            actionText = "나가기",
+            neutralOnClick = { /*TODO*/ },
+            actionOnClick = { method(id) }
+        )
+    }
+}

--- a/designsystem/src/main/java/hous/release/designsystem/component/HousDialog.kt
+++ b/designsystem/src/main/java/hous/release/designsystem/component/HousDialog.kt
@@ -10,12 +10,15 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import hous.release.designsystem.theme.HousBlack
 import hous.release.designsystem.theme.HousG5
 import hous.release.designsystem.theme.HousRed
@@ -23,6 +26,37 @@ import hous.release.designsystem.theme.HousTheme
 
 @Composable
 fun HousDialog(
+    title: String,
+    content: String,
+    neutralText: String,
+    actionText: String,
+    actionOnClick: () -> Unit,
+    onDismissRequest: () -> Unit,
+    properties: DialogProperties = DialogProperties()
+) {
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = properties
+    ) {
+        Surface(
+            modifier = Modifier,
+            shape = RoundedCornerShape(8.dp),
+            color = Color.White
+        ) {
+            HousDialogFrame(
+                title = title,
+                content = content,
+                neutralText = neutralText,
+                actionText = actionText,
+                actionOnClick = actionOnClick,
+                neutralOnClick = onDismissRequest
+            )
+        }
+    }
+}
+
+@Composable
+private fun HousDialogFrame(
     title: String,
     content: String,
     neutralText: String,
@@ -64,7 +98,6 @@ private fun HousDialogSlot(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(8.dp))
             .padding(
                 top = 24.dp,
                 bottom = 20.dp,
@@ -107,7 +140,7 @@ private fun HousDialogPreview() {
             content = "정말 취소하려면 나가기 버튼을 눌러주세요.",
             neutralText = "계속 수정하기",
             actionText = "나가기",
-            neutralOnClick = { /*TODO*/ },
+            onDismissRequest = { /*TODO*/ },
             actionOnClick = {}
         )
     }
@@ -127,7 +160,7 @@ private fun HousDialogPreview2() {
             content = "정말 취소하려면 나가기 버튼을 눌러주세요.",
             neutralText = "계속 수정하기",
             actionText = "나가기",
-            neutralOnClick = { /*TODO*/ },
+            onDismissRequest = { /*TODO*/ },
             actionOnClick = { method(id) }
         )
     }

--- a/feature/todo/src/main/java/hous/release/feature/todo/detail/TodoDetailScreen.kt
+++ b/feature/todo/src/main/java/hous/release/feature/todo/detail/TodoDetailScreen.kt
@@ -19,9 +19,11 @@ import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.Text
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -29,6 +31,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import hous.release.designsystem.component.FabScreenSlot
+import hous.release.designsystem.component.HousDialog
 import hous.release.designsystem.component.HousSearchTextField
 import hous.release.designsystem.theme.HousG5
 import hous.release.designsystem.theme.HousTheme
@@ -64,6 +67,23 @@ fun TodoDetailScreen(
     val bottomSheetState =
         rememberModalBottomSheetState(initialValue = ModalBottomSheetValue.Hidden)
     val (selected, setSelected) = remember(calculation = { mutableStateOf(FILTER_BOTTOM_SHEET) })
+    var isDeleteTodo by remember { mutableStateOf(false) }
+
+    if (isDeleteTodo) {
+        HousDialog(
+            title = stringResource(R.string.todo_delete_title),
+            content = stringResource(R.string.todo_delete_content),
+            neutralText = stringResource(R.string.todo_delete_cancel),
+            actionText = stringResource(R.string.todo_delete_remove),
+            actionOnClick = {
+                coroutineScope.launch {
+                    todoDetailViewModel.deleteTodo()
+                    isDeleteTodo = false
+                    bottomSheetState.hide()
+                }
+            },
+            onDismissRequest = { isDeleteTodo = false })
+    }
 
     ModalBottomSheetLayout(
         sheetState = bottomSheetState,
@@ -87,12 +107,7 @@ fun TodoDetailScreen(
                         bottomSheetState.hide()
                     }
                 },
-                deleteAction = {
-                    coroutineScope.launch {
-                        /* TODO delete dialog 띄우기 */
-                        bottomSheetState.hide()
-                    }
-                }
+                deleteAction = { isDeleteTodo = true }
             )
         }
     ) {

--- a/feature/todo/src/main/java/hous/release/feature/todo/detail/TodoDetailScreen.kt
+++ b/feature/todo/src/main/java/hous/release/feature/todo/detail/TodoDetailScreen.kt
@@ -254,8 +254,8 @@ private fun BottomSheetContent(
     getTodosAppliedFilter: () -> Unit,
     selectDayOfWeek: (Int) -> Unit,
     selectHomy: (Int) -> Unit,
-    editAction: (Int) -> Unit,
-    deleteAction: (Int) -> Unit
+    editAction: () -> Unit,
+    deleteAction: () -> Unit
 ) {
     when (selected) {
         FILTER_BOTTOM_SHEET -> {

--- a/feature/todo/src/main/java/hous/release/feature/todo/detail/TodoDetailScreen.kt
+++ b/feature/todo/src/main/java/hous/release/feature/todo/detail/TodoDetailScreen.kt
@@ -82,7 +82,8 @@ fun TodoDetailScreen(
                     bottomSheetState.hide()
                 }
             },
-            onDismissRequest = { isDeleteTodo = false })
+            onDismissRequest = { isDeleteTodo = false }
+        )
     }
 
     ModalBottomSheetLayout(

--- a/feature/todo/src/main/java/hous/release/feature/todo/detail/TodoDetailViewModel.kt
+++ b/feature/todo/src/main/java/hous/release/feature/todo/detail/TodoDetailViewModel.kt
@@ -141,6 +141,10 @@ class TodoDetailViewModel @Inject constructor(
     fun setTodoDetail(todoId: Int) {
     }
 
+    fun deleteTodo() {
+        /* todoDetail.value.todoId 를 통해 delete 진행 */
+    }
+
     companion object {
         private val WEEK = listOf("월", "화", "수", "목", "금", "토", "일")
     }

--- a/feature/todo/src/main/java/hous/release/feature/todo/detail/component/TodoDetailBottomSheet.kt
+++ b/feature/todo/src/main/java/hous/release/feature/todo/detail/component/TodoDetailBottomSheet.kt
@@ -27,11 +27,10 @@ import hous.release.domain.entity.TodoDetail.User
 @Composable
 fun TodoDetailBottomSheet(
     todoDetail: TodoDetail,
-    editAction: (Int) -> Unit,
-    deleteAction: (Int) -> Unit
+    editAction: () -> Unit,
+    deleteAction: () -> Unit
 ) {
     HousDetailBottomSheet(
-        todoId = todoDetail.todoId,
         content = {
             TodoDetailBottomSheetContent(
                 todo = todoDetail.name,

--- a/feature/todo/src/main/res/values/strings.xml
+++ b/feature/todo/src/main/res/values/strings.xml
@@ -14,6 +14,10 @@
     <string name="todo_detail_textfield_hint">검색하기</string>
     <string name="todo_detail_empty">아직 우리집 to-do가 없어요!</string>
     <string name="todo_filter_empty">해당되는 to-do가 없어요!</string>
+    <string name="todo_delete_title">안녕, to-do...</string>
+    <string name="todo_delete_content">to-do는 한 번 삭제하면 복구되지 않아요.</string>
+    <string name="todo_delete_cancel">취소하기</string>
+    <string name="todo_delete_remove">삭제하기</string>
     <string-array name="to_do_week_of_day">
         <item>월</item>
         <item>화</item>


### PR DESCRIPTION
## 관련 이슈
- closed #230 
 
https://github.com/Hous-Release/hous-AOS/assets/82709044/1b7da88a-46df-4d2b-a2f4-f7d10aff9cea 

## 작업한 내용
- 연주누나가 만든 dialog 를 사용하고 싶었지만 feature 모듈로 쓰려고 하면 종속성 폭탄이 생겨서 compose dialog 를 만들었습니다...
- 디자인시스템 모듈에 있는 바텀시트 메서드를 수정했습니다. 
   `(Int) -> Unit` -> `() -> Unit`
    왜냐하면, 서버 통신을 통해 todoDetail 또는 ruleDetail 을 가지고 있어서 todoId, ruleId를 이미 viewmodel에서 보유 중이기 때문에 굳이 파라미터로 id 값을 넣지 않아도 viewmodel에서 해결할 수 있기 때문입니다.

## PR 포인트
- compose 코드
