### PR TITLE
#264 [UI/ Feat] main rule 화면

### DIFF
--- a/app/src/main/java/hous/release/android/presentation/our_rules/component/main/MainRuleContent.kt
+++ b/app/src/main/java/hous/release/android/presentation/our_rules/component/main/MainRuleContent.kt
@@ -1,0 +1,74 @@
+package hous.release.android.presentation.our_rules.component.main
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import hous.release.android.R
+import hous.release.designsystem.theme.HousG5
+import hous.release.designsystem.theme.HousTheme
+import hous.release.domain.entity.rule.MainRule
+
+@Composable
+fun MainRuleContent(
+    onNavigateToDetailRule: (Int) -> Unit = {},
+    mainRules: List<MainRule> = emptyList()
+) {
+    if (mainRules.isEmpty()) {
+        MainRuleEmptyContent()
+    } else {
+        Spacer(modifier = Modifier.height(16.dp))
+        MainRuleList(
+            onNavigateToDetailRule = onNavigateToDetailRule,
+            mainRules = mainRules
+        )
+    }
+}
+
+@Composable
+fun MainRuleEmptyContent() {
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(top = 88.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = stringResource(id = R.string.hous_empty_our_rules),
+            color = HousG5,
+            style = HousTheme.typography.b2
+        )
+    }
+}
+
+@Preview(name = "empty content", showBackground = true)
+@Composable
+private fun EmptyContentPreview() {
+    HousTheme {
+        Surface {
+            MainRuleContent()
+        }
+    }
+}
+
+@Preview(name = "MainRuleContent", showBackground = true)
+@Composable
+private fun MainRuleContentPreview() {
+    HousTheme {
+        MainRuleContent(
+            mainRules = listOf(
+                MainRule().copy(id = 1, name = "test1", isNew = true),
+                MainRule().copy(id = 2, name = "test2", isNew = false),
+                MainRule().copy(id = 3, name = "test3", isNew = true),
+                MainRule().copy(id = 4, name = "test4", isNew = false)
+            )
+        )
+    }
+}

--- a/app/src/main/java/hous/release/android/presentation/our_rules/component/main/MainRuleDropDownMenu.kt
+++ b/app/src/main/java/hous/release/android/presentation/our_rules/component/main/MainRuleDropDownMenu.kt
@@ -1,0 +1,129 @@
+package hous.release.android.presentation.our_rules.component.main
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material.Button
+import androidx.compose.material.Divider
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import hous.release.designsystem.theme.HousBlue
+import hous.release.designsystem.theme.HousG2
+import hous.release.designsystem.theme.HousG6
+import hous.release.designsystem.theme.HousTheme
+
+private val MinMenuWidth = 139.dp
+private val DropdownMenuItemContentStartPadding = 20.dp
+private val DropdownDividerPadding = 14.dp
+
+@Composable
+fun MainRuleDropDownMenu(
+    isExpanded: Boolean = false,
+    onDismiss: () -> Unit,
+    onNavigateToRepresentation: () -> Unit = {},
+    onNavigateToGuide: () -> Unit = {}
+) {
+    // device width dp
+    val configuration = LocalConfiguration.current
+    val screenWidth = configuration.screenWidthDp.dp
+    // dropdown menu offset
+
+    val dropDownOffset = DpOffset(x = screenWidth - MinMenuWidth - 32.dp, y = (-8).dp)
+
+    DropdownMenu(
+        modifier = Modifier
+            .wrapContentSize()
+            .sizeIn(minWidth = MinMenuWidth),
+        offset = dropDownOffset,
+        expanded = isExpanded,
+        onDismissRequest = onDismiss
+    ) {
+        DropdownMenuItem(
+            onClick = onNavigateToRepresentation,
+            contentPadding = PaddingValues(start = DropdownMenuItemContentStartPadding)
+        ) {
+            Text(
+                text = "Rules 편집",
+                style = HousTheme.typography.b2,
+                color = HousBlue,
+                modifier = Modifier.wrapContentSize()
+            )
+        }
+        Divider(
+            color = HousG2,
+            thickness = 1.dp,
+            modifier = Modifier.padding(horizontal = DropdownDividerPadding)
+        )
+        DropdownMenuItem(
+            onClick = onNavigateToGuide,
+            contentPadding = PaddingValues(start = DropdownMenuItemContentStartPadding)
+        ) {
+            Text(
+                text = "가이드 다시보기",
+                style = HousTheme.typography.b2,
+                color = HousG6,
+                modifier = Modifier.wrapContentSize()
+            )
+        }
+    }
+}
+
+@Preview(name = "MainRuleDropDown", showBackground = true)
+@Composable
+fun PreviewMainRuleDropDown() {
+    HousTheme {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            var expanded by remember { mutableStateOf(false) }
+            val onClick = { expanded = !expanded }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .wrapContentSize(align = Alignment.TopEnd)
+            ) {
+                Button(onClick = onClick) {
+                    Text(text = "Click me")
+                }
+                MainRuleDropDownMenu(
+                    expanded,
+                    { expanded = false }
+                )
+            }
+            var expanded2 by remember { mutableStateOf(false) }
+            val onClick2 = { expanded2 = !expanded2 }
+            Box(
+                modifier = Modifier
+                    .wrapContentSize()
+            ) {
+                Button(onClick = onClick2) {
+                    Text(text = "Click me")
+                }
+                MainRuleDropDownMenu(
+                    expanded2,
+                    { expanded2 = false }
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/hous/release/android/presentation/our_rules/component/main/MainRuleList.kt
+++ b/app/src/main/java/hous/release/android/presentation/our_rules/component/main/MainRuleList.kt
@@ -1,0 +1,81 @@
+package hous.release.android.presentation.our_rules.component.main
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import hous.release.designsystem.component.HousDash
+import hous.release.designsystem.component.HousRuleSlot
+import hous.release.designsystem.theme.HousBlue
+import hous.release.designsystem.theme.HousTheme
+import hous.release.domain.entity.rule.MainRule
+
+@Composable
+fun MainRuleList(
+    onNavigateToDetailRule: (Int) -> Unit = {},
+    mainRules: List<MainRule> = emptyList()
+) {
+    LazyColumn {
+        itemsIndexed(mainRules, key = { _, rule -> rule.id }) { _, rule ->
+            MainRuleItem(
+                onClick = { onNavigateToDetailRule(rule.id) },
+                mainRule = rule
+            )
+        }
+    }
+}
+
+@Composable
+private fun MainRuleItem(
+    onClick: () -> Unit = {},
+    mainRule: MainRule = MainRule()
+) {
+    HousRuleSlot(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(start = 6.dp, top = 12.dp, bottom = 12.dp),
+        text = mainRule.name,
+        isShowTrailingIcon = mainRule.isNew,
+        leadingIcon = {
+            HousDash(mainRule.isNew)
+        },
+        trailingIcon = {
+            Text(
+                modifier = Modifier.padding(end = 16.dp),
+                text = "new !",
+                color = HousBlue,
+                style = HousTheme.typography.en2
+            )
+        }
+    )
+}
+
+@Preview(name = "main rule Item", showBackground = true)
+@Composable
+private fun MainRulePreview() {
+    HousTheme {
+        Surface {
+            MainRuleItem()
+        }
+    }
+}
+
+@Preview(name = "new main rule Item", showBackground = true)
+@Composable
+private fun NewMainRulePreview() {
+    HousTheme {
+        Surface {
+            MainRuleItem(
+                mainRule = MainRule().copy(isNew = true)
+            )
+        }
+    }
+}

--- a/app/src/main/java/hous/release/android/presentation/our_rules/component/main/MainRuleToolbar.kt
+++ b/app/src/main/java/hous/release/android/presentation/our_rules/component/main/MainRuleToolbar.kt
@@ -1,53 +1,69 @@
 package hous.release.android.presentation.our_rules.component.main
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.Icon
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import hous.release.designsystem.R
 import hous.release.designsystem.component.HousToolbarSlot
 import hous.release.designsystem.theme.HousG4
 import hous.release.designsystem.theme.HousTheme
-import hous.release.android.R.drawable as app
-import hous.release.designsystem.R.drawable as feature
 
 @Composable
 fun MainRuleToolbar(
-    onBack: () -> Unit = {},
     onClickSetting: () -> Unit = {},
-    title: String = "우리 집 Rules"
+    modifier: Modifier = Modifier,
+    title: String = "우리 집 Rules",
+    onBack: () -> Unit = { }
 ) {
-    HousToolbarSlot(
+    var expanded by remember { mutableStateOf(false) }
+    val onDismiss = { expanded = false }
+    Box(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(top = 20.dp, bottom = 24.dp, end = 8.dp),
-        leadingIcon = {
-            Icon(
-                modifier = Modifier.clickable {
-                    onBack()
-                },
-                tint = HousG4,
-                painter = painterResource(id = feature.ic_back),
-                contentDescription = null
-            )
-        },
-        title = title,
-        trailingIcon = {
-            Icon(
-                modifier = Modifier.clickable {
-                    onClickSetting()
-                },
-                tint = HousG4,
-                painter = painterResource(id = app.ic_our_rules_setting),
-                contentDescription = null
-            )
-        }
-    )
+            .wrapContentSize(align = Alignment.TopEnd)
+    ) {
+        HousToolbarSlot(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(top = 20.dp, bottom = 24.dp, end = 8.dp),
+            leadingIcon = {
+                Icon(
+                    modifier = Modifier.clickable {
+                        onBack()
+                    },
+                    tint = HousG4,
+                    painter = painterResource(id = R.drawable.ic_back),
+                    contentDescription = null
+                )
+            },
+            title = title,
+            trailingIcon = {
+                Icon(
+                    modifier = Modifier.clickable {
+                        expanded = true
+                    },
+                    tint = HousG4,
+                    painter = painterResource(id = hous.release.android.R.drawable.ic_our_rules_setting),
+                    contentDescription = null
+                )
+            }
+        )
+        MainRuleDropDownMenu(expanded, onDismiss)
+    }
 }
 
 @Preview

--- a/app/src/main/java/hous/release/android/presentation/our_rules/component/main/MainRuleToolbar.kt
+++ b/app/src/main/java/hous/release/android/presentation/our_rules/component/main/MainRuleToolbar.kt
@@ -1,0 +1,61 @@
+package hous.release.android.presentation.our_rules.component.main
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Icon
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import hous.release.designsystem.component.HousToolbarSlot
+import hous.release.designsystem.theme.HousG4
+import hous.release.designsystem.theme.HousTheme
+import hous.release.android.R.drawable as app
+import hous.release.designsystem.R.drawable as feature
+
+@Composable
+fun MainRuleToolbar(
+    onBack: () -> Unit = {},
+    onClickSetting: () -> Unit = {},
+    title: String = "우리 집 Rules"
+) {
+    HousToolbarSlot(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 20.dp, bottom = 24.dp, end = 8.dp),
+        leadingIcon = {
+            Icon(
+                modifier = Modifier.clickable {
+                    onBack()
+                },
+                tint = HousG4,
+                painter = painterResource(id = feature.ic_back),
+                contentDescription = null
+            )
+        },
+        title = title,
+        trailingIcon = {
+            Icon(
+                modifier = Modifier.clickable {
+                    onClickSetting()
+                },
+                tint = HousG4,
+                painter = painterResource(id = app.ic_our_rules_setting),
+                contentDescription = null
+            )
+        }
+    )
+}
+
+@Preview
+@Composable
+fun PreviewMainRuleToolbar() {
+    HousTheme {
+        Surface {
+            MainRuleToolbar()
+        }
+    }
+}

--- a/app/src/main/java/hous/release/android/presentation/our_rules/screen/MainRuleScreen.kt
+++ b/app/src/main/java/hous/release/android/presentation/our_rules/screen/MainRuleScreen.kt
@@ -1,36 +1,92 @@
 package hous.release.android.presentation.our_rules.screen
 
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.Button
-import androidx.compose.material.Text
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import hous.release.android.presentation.our_rules.component.main.MainRuleContent
+import hous.release.android.presentation.our_rules.component.main.MainRuleToolbar
+import hous.release.designsystem.component.FabScreenSlot
+import hous.release.designsystem.component.HousSearchTextField
 import hous.release.designsystem.theme.HousTheme
+import hous.release.domain.entity.rule.MainRule
+import hous.release.feature.todo.R
 
 @Composable
 fun MainRuleScreen(
+    mainRules: List<MainRule> = emptyList(),
+    searchQuery: String = "",
+    onSearch: (String) -> Unit = {},
     onNavigateToDetailRule: (Int) -> Unit = {},
-    onNavigateToAddRule: () -> Unit = {}
+    onNavigateToAddRule: () -> Unit = {},
+    onBack: () -> Boolean = { false },
+    onFinish: () -> Unit = {}
 ) {
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+    val focusManager = LocalFocusManager.current
+    FabScreenSlot(
+        fabOnClick = onNavigateToAddRule
     ) {
-        Button(onClick = onNavigateToAddRule) {
-            Text(
-                text = "Add Rule",
-                style = HousTheme.typography.h1
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(
+                    start = 16.dp,
+                    end = 16.dp,
+                    top = 20.dp
+                ).pointerInput(Unit) {
+                    detectTapGestures(
+                        onTap = {
+                            focusManager.clearFocus()
+                        }
+                    )
+                },
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            MainRuleToolbar(
+                onBack = onFinish
+            )
+            Spacer(modifier = Modifier.padding(top = 4.dp))
+            HousSearchTextField(
+                text = searchQuery,
+                onTextChange = onSearch,
+                hint = stringResource(R.string.todo_detail_textfield_hint)
+            )
+            MainRuleContent(
+                mainRules = mainRules,
+                onNavigateToDetailRule = onNavigateToDetailRule
             )
         }
-        Button(onClick = { onNavigateToDetailRule(1) }) {
-            Text(
-                text = "Detail Rule",
-                style = HousTheme.typography.h1
+    }
+}
+
+@Preview(name = "MainRuleScreen", showBackground = true)
+@Composable
+private fun MainRuleScreenPreView2() {
+    HousTheme {
+        MainRuleScreen(
+            mainRules = listOf(
+                MainRule().copy(id = 1, name = "test1", isNew = true),
+                MainRule().copy(id = 2, name = "test2", isNew = false),
+                MainRule().copy(id = 3, name = "test3", isNew = true),
+                MainRule().copy(id = 4, name = "test4", isNew = false)
             )
-        }
+        )
+    }
+}
+
+@Preview(name = "MainRuleScreen - empty Main Rules", showBackground = true)
+@Composable
+private fun MainRuleScreenPreView() {
+    HousTheme {
+        MainRuleScreen()
     }
 }

--- a/app/src/main/java/hous/release/android/presentation/our_rules/screen/graph/RuleNavGraph.kt
+++ b/app/src/main/java/hous/release/android/presentation/our_rules/screen/graph/RuleNavGraph.kt
@@ -1,6 +1,10 @@
 package hous.release.android.presentation.our_rules.screen.graph
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
@@ -9,6 +13,8 @@ import androidx.navigation.compose.composable
 import hous.release.android.presentation.our_rules.screen.AddRuleScreen
 import hous.release.android.presentation.our_rules.screen.MainRuleScreen
 import hous.release.android.presentation.our_rules.screen.RulesScreens
+import hous.release.android.presentation.our_rules.viewmodel.MainRuleViewModel
+import hous.release.android.presentation.practice.findActivity
 
 @Composable
 fun RuleNavGraph(
@@ -21,7 +27,8 @@ fun RuleNavGraph(
     ) {
         mainRuleScreen(
             onNavigateToAddRule = navController::navigateToAddRule,
-            onNavigateToDetailRule = navController::navigateToDetailRuleGraph
+            onNavigateToDetailRule = navController::navigateToDetailRuleGraph,
+            onBack = navController::popBackStack
         )
         addRuleScreen()
         ruleDetailsGraph(navController)
@@ -30,14 +37,25 @@ fun RuleNavGraph(
 
 // Screens
 
+@OptIn(ExperimentalLifecycleComposeApi::class)
 private fun NavGraphBuilder.mainRuleScreen(
     onNavigateToAddRule: () -> Unit,
-    onNavigateToDetailRule: (Int) -> Unit
+    onNavigateToDetailRule: (Int) -> Unit,
+    onBack: () -> Boolean
 ) {
     composable(RulesScreens.Main.route) {
+        val activity = LocalContext.current.findActivity()
+        val viewModel = hiltViewModel<MainRuleViewModel>()
+        val uiState = viewModel.uiState.collectAsStateWithLifecycle()
+
         MainRuleScreen(
+            mainRules = uiState.value.filteredRules,
+            searchQuery = uiState.value.searchQuery,
+            onSearch = viewModel::searchRule,
             onNavigateToAddRule = onNavigateToAddRule,
-            onNavigateToDetailRule = onNavigateToDetailRule
+            onNavigateToDetailRule = onNavigateToDetailRule,
+            onBack = onBack,
+            onFinish = activity::finish
         )
     }
 }

--- a/app/src/main/java/hous/release/android/presentation/our_rules/viewmodel/MainRuleViewModel.kt
+++ b/app/src/main/java/hous/release/android/presentation/our_rules/viewmodel/MainRuleViewModel.kt
@@ -1,0 +1,60 @@
+package hous.release.android.presentation.our_rules.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import hous.release.domain.entity.rule.MainRule
+import hous.release.domain.usecase.rule.GetMainRulesUseCase
+import hous.release.domain.usecase.search.SearchRuleUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+class MainRuleViewModel @Inject constructor(
+    private val getMainRulesUseCase: GetMainRulesUseCase,
+    private val searcher: SearchRuleUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(MainRules())
+    val uiState = _uiState.asStateFlow()
+
+    init {
+        fetchMainRules()
+    }
+
+    fun fetchMainRules() {
+        viewModelScope.launch {
+            runCatching { getMainRulesUseCase() }
+                .onSuccess { rules ->
+                    _uiState.update {
+                        MainRules(
+                            originRules = rules,
+                            filteredRules = rules
+                        )
+                    }
+                }
+                .onFailure {
+                    Timber.e(it.stackTraceToString())
+                }
+        }
+    }
+
+    fun searchRule(searchQuery: String) {
+        _uiState.update { state ->
+            state.copy(
+                searchQuery = searchQuery,
+                filteredRules = searcher(searchQuery, state.originRules)
+            )
+        }
+    }
+}
+
+data class MainRules(
+    val originRules: List<MainRule> = emptyList(),
+    val filteredRules: List<MainRule> = emptyList(),
+    val searchQuery: String = ""
+)

--- a/app/src/main/res/layout/fragment_to_do.xml
+++ b/app/src/main/res/layout/fragment_to_do.xml
@@ -260,8 +260,8 @@
             android:id="@+id/cv_to_do_floating_btn"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="12dp"
-            android:layout_marginBottom="20dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginBottom="4dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_to_do.xml
+++ b/app/src/main/res/layout/fragment_to_do.xml
@@ -260,8 +260,8 @@
             android:id="@+id/cv_to_do_floating_btn"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="36dp"
-            android:layout_marginBottom="32dp"
+            android:layout_marginEnd="12dp"
+            android:layout_marginBottom="20dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/designsystem/src/main/java/hous/release/designsystem/component/HousDash.kt
+++ b/designsystem/src/main/java/hous/release/designsystem/component/HousDash.kt
@@ -1,0 +1,44 @@
+package hous.release.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import hous.release.designsystem.theme.HousBlueL1
+import hous.release.designsystem.theme.HousG3
+import hous.release.designsystem.theme.HousTheme
+
+@Composable
+fun HousDash(
+    isNew: Boolean = false
+) {
+    Box(
+        modifier = Modifier
+            .padding(8.dp)
+            .size(8.dp)
+            .clip(CircleShape)
+            .background(if (isNew) HousBlueL1 else HousG3)
+    )
+}
+
+@Preview(name = "newType - hous dash", showBackground = true)
+@Composable
+private fun HousDashPreview() {
+    HousTheme {
+        HousDash(isNew = true)
+    }
+}
+
+@Preview(name = "hous dash", showBackground = true)
+@Composable
+private fun HousDashPreview2() {
+    HousTheme {
+        HousDash()
+    }
+}

--- a/designsystem/src/main/java/hous/release/designsystem/component/HousFloatingButton.kt
+++ b/designsystem/src/main/java/hous/release/designsystem/component/HousFloatingButton.kt
@@ -52,7 +52,17 @@ fun HousFloatingButton(
 }
 
 @Composable
-@Preview
+@Preview(showBackground = true)
 fun Preview() {
     HousFloatingButton()
+}
+
+@Composable
+@Preview(widthDp = 360, heightDp = 640, showBackground = true)
+fun PreviewFabContainerWithContent() {
+    FabScreenSlot(
+        fabOnClick = {},
+        content = {
+        }
+    )
 }

--- a/designsystem/src/main/java/hous/release/designsystem/component/HousFloatingButton.kt
+++ b/designsystem/src/main/java/hous/release/designsystem/component/HousFloatingButton.kt
@@ -1,21 +1,21 @@
 package hous.release.designsystem.component
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.FloatingActionButton
+import androidx.compose.material.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import hous.release.designsystem.R
 import hous.release.designsystem.theme.HousBlue
+import hous.release.designsystem.theme.HousWhite
 
 @Composable
 fun FabScreenSlot(
@@ -35,19 +35,23 @@ fun FabScreenSlot(
 
 @Composable
 fun HousFloatingButton(
-    onClick: () -> Unit
+    onClick: () -> Unit = {}
 ) {
-    Box(
-        modifier = Modifier
-            .clip(CircleShape)
-            .background(HousBlue)
-            .clickable { onClick() }
-            .size(60.dp),
-        contentAlignment = Alignment.Center
+    FloatingActionButton(
+        onClick = onClick,
+        backgroundColor = HousBlue,
+        contentColor = HousWhite,
+        modifier = Modifier.size(92.dp).padding(16.dp)
     ) {
-        Image(
-            painter = painterResource(id = R.drawable.ic_plus),
-            contentDescription = null
+        Icon(
+            imageVector = ImageVector.vectorResource(id = R.drawable.ic_plus),
+            contentDescription = "Add"
         )
     }
+}
+
+@Composable
+@Preview
+fun Preview() {
+    HousFloatingButton()
 }

--- a/designsystem/src/main/java/hous/release/designsystem/component/HousFloatingButton.kt
+++ b/designsystem/src/main/java/hous/release/designsystem/component/HousFloatingButton.kt
@@ -19,6 +19,7 @@ import hous.release.designsystem.theme.HousWhite
 
 @Composable
 fun FabScreenSlot(
+    modifier: Modifier = Modifier,
     fabOnClick: () -> Unit,
     content: @Composable () -> Unit
 ) {
@@ -26,7 +27,7 @@ fun FabScreenSlot(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .padding(end = 28.dp, bottom = 36.dp),
+            .padding(end = 12.dp, bottom = 20.dp),
         contentAlignment = Alignment.BottomEnd
     ) {
         HousFloatingButton { fabOnClick() }

--- a/designsystem/src/main/java/hous/release/designsystem/component/HousRule.kt
+++ b/designsystem/src/main/java/hous/release/designsystem/component/HousRule.kt
@@ -1,27 +1,20 @@
 package hous.release.designsystem.component
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import hous.release.designsystem.theme.HousBlue
-import hous.release.designsystem.theme.HousBlueL1
 import hous.release.designsystem.theme.HousG2
-import hous.release.designsystem.theme.HousG3
 import hous.release.designsystem.theme.HousG7
 import hous.release.designsystem.theme.HousTheme
 
@@ -66,13 +59,7 @@ fun HousEditRulePreview() {
             text = "text",
             isShowTrailingIcon = false,
             leadingIcon = {
-                Box(
-                    modifier = Modifier
-                        .padding(8.dp)
-                        .size(8.dp)
-                        .clip(CircleShape)
-                        .background(if (true) HousBlueL1 else HousG3)
-                )
+                HousDash(true)
             },
             trailingIcon = {
                 Text(
@@ -97,13 +84,7 @@ fun HousRulePreview() {
             text = "text",
             isShowTrailingIcon = false,
             leadingIcon = {
-                Box(
-                    modifier = Modifier
-                        .padding(8.dp)
-                        .size(8.dp)
-                        .clip(CircleShape)
-                        .background(if (false) HousBlueL1 else HousG3)
-                )
+                HousDash()
             },
             trailingIcon = {
                 Text(

--- a/domain/src/main/java/hous/release/domain/entity/rule/MainRule.kt
+++ b/domain/src/main/java/hous/release/domain/entity/rule/MainRule.kt
@@ -1,11 +1,13 @@
 package hous.release.domain.entity.rule
 
+import hous.release.domain.entity.Rule
+
 data class MainRule(
-    val id: Int = NO_ID,
-    val name: String = NO_NAME,
+    override val id: Int = NO_ID,
+    override val name: String = NO_NAME,
     val createdAt: String = "",
     val isNew: Boolean = false
-) {
+) : Rule(id, name) {
     companion object {
         private const val NO_NAME = "다른 Rule도 추가해보세요!"
         private const val NO_ID = -1

--- a/feature/todo/src/main/java/hous/release/feature/todo/detail/TodoDetailScreen.kt
+++ b/feature/todo/src/main/java/hous/release/feature/todo/detail/TodoDetailScreen.kt
@@ -3,6 +3,7 @@
 package hous.release.feature.todo.detail
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -30,6 +31,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -71,7 +74,7 @@ fun TodoDetailScreen(
     finish: () -> Unit,
     onEvent: (TodoEvent, () -> Unit) -> Unit,
     coroutineScope: CoroutineScope = rememberCoroutineScope(),
-    lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current,
+    lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current
 ) {
     val searchText = todoDetailViewModel.searchText.collectAsStateWithLifecycle()
     val selectedDayOfWeek = todoDetailViewModel.selectedDayOfWeeks.collectAsStateWithLifecycle()
@@ -205,8 +208,17 @@ private fun TodoDetailContent(
     showToDoDetailBottomSheet: (Int) -> Unit,
     finish: () -> Unit
 ) {
+    val focusManager = LocalFocusManager.current
     Column(
-        modifier = Modifier.padding(horizontal = 16.dp)
+        modifier = Modifier
+            .padding(horizontal = 16.dp)
+            .pointerInput(Unit) {
+                detectTapGestures(
+                    onPress = {
+                        focusManager.clearFocus()
+                    }
+                )
+            }
     ) {
         TodoDetailToolbar(finish = finish)
         Spacer(modifier = Modifier.height(4.dp))
@@ -285,8 +297,15 @@ private fun TodoFilterAndSearchResult(
 private fun EmptyGuideText(
     searchText: String
 ) {
+    val focusManager = LocalFocusManager.current
     Box(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier.fillMaxSize().pointerInput(Unit) {
+            detectTapGestures(
+                onPress = {
+                    focusManager.clearFocus()
+                }
+            )
+        },
         contentAlignment = Alignment.Center
     ) {
         Text(
@@ -320,6 +339,7 @@ private fun BottomSheetContent(
                 getTodosAppliedFilter = getTodosAppliedFilter
             )
         }
+
         DETAIL_BOTTOM_SHEET -> {
             TodoDetailBottomSheet(
                 todoDetail = todoDetail,

--- a/feature/todo/src/main/java/hous/release/feature/todo/detail/component/ToDoItem.kt
+++ b/feature/todo/src/main/java/hous/release/feature/todo/detail/component/ToDoItem.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import hous.release.designsystem.component.HousRuleSlot
@@ -26,10 +27,14 @@ fun ToDoItem(
     todo: TodoWithNew,
     showToDoDetailBottomSheet: (Int) -> Unit
 ) {
+    val focusManager = LocalFocusManager.current
     HousRuleSlot(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable { showToDoDetailBottomSheet(todo.id) }
+            .clickable {
+                focusManager.clearFocus()
+                showToDoDetailBottomSheet(todo.id)
+            }
             .padding(start = 6.dp, top = 12.dp, bottom = 12.dp),
         text = todo.name,
         isShowTrailingIcon = todo.isNew,

--- a/feature/todo/src/main/java/hous/release/feature/todo/detail/component/TodoFilter.kt
+++ b/feature/todo/src/main/java/hous/release/feature/todo/detail/component/TodoFilter.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -39,11 +40,15 @@ fun TodoFilter(
     isShowBottomSheet: Boolean,
     showFilterBottomSheet: () -> Unit
 ) {
+    val focusManager = LocalFocusManager.current
     Box(
         modifier = Modifier
             .clip(RoundedCornerShape(25.dp))
             .background(if (isShowBottomSheet) HousBlue else HousBlueL2)
-            .clickable { showFilterBottomSheet() }
+            .clickable {
+                focusManager.clearFocus()
+                showFilterBottomSheet()
+            }
             .padding(
                 vertical = 6.dp,
                 horizontal = 12.dp


### PR DESCRIPTION
## 관련 이슈
- closed #264  

## 작업한 내용
https://github.com/Hous-Release/hous-AOS/assets/87055456/c403c9a9-c683-4d98-a8f1-0edc880eb5f3


- main Rule Screen 구현
- MainRuleViewModel 구현
- 다른 화면 navigate 로직 구현
- textField 외부 tab or click 시 focus clear
- HousFloatingButton 수정
     - Rule이랑 Todo랑 padding이 다르길래.. 9c5686a68a21acfceb6476cda968bd75d85457a7

## PR 포인트
@KWY0218 
- todo 쪽에도 focus clear 하는 로직 추가하였습니다! eba07cdbe24663c726bd74fb54c804cc04076bc9
- 머터리얼의 FloatingActionButton을 사용하여 HousFloatingButton 수정하였습니다(이유는 shadow효과 주고싶어서?) eba07cdbe24663c726bd74fb54c804cc04076bc9

- DropDownMenu 위치 조절하는게 매우 빡세서  아래와와 같이 offset 조절을 통해 위치를 정했는데, 다른 좋은 방법이 있을까용..? [91371ce](https://github.com/Hous-Release/hous-AOS/pull/268/commits/91371ceefe56b63f39f0e08e590b721410d33ffd)

![image](https://github.com/Hous-Release/hous-AOS/assets/87055456/9b01a26e-f943-4b5d-b343-c532c6abbcb2)

![스크린샷 2023-07-23 오전 4 31 56](https://github.com/Hous-Release/hous-AOS/assets/87055456/1d0ee2f3-e149-44a4-ad22-9bbdafa74c9f)

