### PR TITLE
#279 [refactor] compose textfield

### DIFF
--- a/app/src/main/java/hous/release/android/util/component/ToDoUserScreen.kt
+++ b/app/src/main/java/hous/release/android/util/component/ToDoUserScreen.kt
@@ -14,6 +14,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
@@ -22,22 +24,27 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import hous.release.android.R
 import hous.release.android.presentation.our_rules.type.ButtonState
 import hous.release.android.presentation.todo.viewmodel.UpdateToDoUiState
-import hous.release.designsystem.component.HousLeftLimitedTextField
+import hous.release.designsystem.component.HousTextField
 import hous.release.designsystem.component.HousToolbarSlot
+import hous.release.designsystem.component.RIGHT_LIMITED_TEXT_FIELD
 import hous.release.designsystem.theme.HousBlack
 import hous.release.designsystem.theme.HousBlue
 import hous.release.designsystem.theme.HousBlueL1
-import hous.release.designsystem.theme.HousG1
 import hous.release.designsystem.theme.HousG4
 import hous.release.designsystem.theme.HousRed
 import hous.release.designsystem.theme.HousTheme
@@ -51,6 +58,7 @@ fun TodoUserScreen(
     todoText: String,
     buttonText: String,
     uiState: UpdateToDoUiState,
+    localFocusManager: FocusManager = LocalFocusManager.current,
     setTodoText: (String) -> Unit,
     checkUser: (Int) -> Unit,
     selectTodoDay: (Int, Int) -> Unit,
@@ -105,12 +113,21 @@ fun TodoUserScreen(
         )
         TodoTitleGuide()
         Spacer(modifier = Modifier.height(4.dp))
-        HousLeftLimitedTextField(
+        HousTextField(
+            textFiledMode = RIGHT_LIMITED_TEXT_FIELD,
             modifier = Modifier,
             text = todoText,
             onTextChange = setTodoText,
-            color = HousG1,
-            limitTextCount = 10
+            limitTextCount = 20,
+            keyboardOptions = KeyboardOptions.Default.copy(
+                capitalization = KeyboardCapitalization.Sentences,
+                autoCorrect = true,
+                keyboardType = KeyboardType.Text,
+                imeAction = ImeAction.Done
+            ),
+            keyboardActions = KeyboardActions(
+                onDone = { localFocusManager.clearFocus() }
+            )
         )
         Spacer(modifier = Modifier.height(8.dp))
         TodoNotificationCheckBox(

--- a/designsystem/src/main/java/hous/release/designsystem/component/HousFloatingButton.kt
+++ b/designsystem/src/main/java/hous/release/designsystem/component/HousFloatingButton.kt
@@ -25,7 +25,7 @@ fun FabScreenSlot(
 ) {
     content()
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .padding(end = 12.dp, bottom = 20.dp),
         contentAlignment = Alignment.BottomEnd

--- a/designsystem/src/main/java/hous/release/designsystem/component/HousTextField.kt
+++ b/designsystem/src/main/java/hous/release/designsystem/component/HousTextField.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalFocusManager
@@ -35,7 +36,6 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import hous.release.designsystem.R
 import hous.release.designsystem.theme.HousBlue
@@ -44,43 +44,9 @@ import hous.release.designsystem.theme.HousG1
 import hous.release.designsystem.theme.HousG5
 import hous.release.designsystem.theme.HousTheme
 
-@Composable
-fun HousBottomLimitedTextField(
-    modifier: Modifier = Modifier,
-    text: String,
-    color: Color,
-    limitTextCount: Int,
-    height: Dp,
-    onTextChange: (String) -> Unit
-) {
-    Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(height)
-            .clip(RoundedCornerShape(8.dp))
-            .background(color)
-            .padding(horizontal = 16.dp, vertical = 12.dp)
-    ) {
-        HousTextField(
-            modifier = Modifier
-                .height(IntrinsicSize.Min)
-                .weight(1f),
-            text = text,
-            onTextChange = { innerText ->
-                if (innerText.length <= limitTextCount) onTextChange(innerText)
-            }
-        )
-        Text(
-            modifier = Modifier
-                .wrapContentSize()
-                .fillMaxWidth(),
-            text = "${text.length}/$limitTextCount",
-            textAlign = TextAlign.End,
-            style = HousTheme.typography.en2,
-            color = HousG5
-        )
-    }
-}
+const val SEARCH_TEXT_FIELD = 0
+const val RIGHT_LIMITED_TEXT_FIELD = 1
+const val BOTTOM_END_TEXT_FIELD = 2
 
 @Composable
 fun HousLeftLimitedTextField(
@@ -99,6 +65,7 @@ fun HousLeftLimitedTextField(
             .padding(horizontal = 16.dp, vertical = 11.dp)
     ) {
         HousTextField(
+            textFiledMode = RIGHT_LIMITED_TEXT_FIELD,
             modifier = Modifier
                 .height(IntrinsicSize.Min)
                 .weight(1f),
@@ -125,6 +92,10 @@ fun HousLeftLimitedTextField(
 }
 
 @Composable
+@Deprecated(
+    "Preview 를 보시고 HousTextField 함수를 사용하시면 됩니다.",
+    replaceWith = ReplaceWith("HousTextField")
+)
 fun HousSearchTextField(
     modifier: Modifier = Modifier,
     text: String,
@@ -133,6 +104,7 @@ fun HousSearchTextField(
     onTextChange: (String) -> Unit
 ) {
     HousTextField(
+        textFiledMode = SEARCH_TEXT_FIELD,
         modifier = modifier
             .fillMaxWidth()
             .height(IntrinsicSize.Min)
@@ -141,7 +113,6 @@ fun HousSearchTextField(
             .padding(horizontal = 16.dp, vertical = 11.dp),
         text = text,
         hint = hint,
-        isPrefixIcon = true,
         keyboardOptions = KeyboardOptions.Default.copy(
             capitalization = KeyboardCapitalization.Sentences,
             autoCorrect = true,
@@ -156,57 +127,141 @@ fun HousSearchTextField(
 }
 
 @Composable
-private fun HousTextField(
+fun HousTextField(
+    textFiledMode: Int,
     modifier: Modifier,
     text: String,
     hint: String = "",
-    isPrefixIcon: Boolean = false,
+    limitTextCount: Int = 20,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
     onTextChange: (String) -> Unit
 ) {
+    var backgroundColor by remember { mutableStateOf(HousG1) }
     BasicTextField(
-        modifier = modifier,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(IntrinsicSize.Min)
+            .clip(RoundedCornerShape(8.dp))
+            .onFocusChanged { focus ->
+                backgroundColor = if (focus.isFocused) HousBlueL2 else HousG1
+            }
+            .background(backgroundColor)
+            .padding(horizontal = 16.dp, vertical = 11.dp),
         value = text,
-        onValueChange = { onTextChange(it) },
+        onValueChange = { innerText ->
+            if (innerText.length <= limitTextCount) onTextChange(innerText)
+        },
         textStyle = HousTheme.typography.b2,
         keyboardOptions = keyboardOptions,
         keyboardActions = keyboardActions,
         cursorBrush = SolidColor(HousBlue)
     ) { innerTextField ->
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            if (isPrefixIcon) {
-                Image(
-                    painter = painterResource(id = R.drawable.ic_search),
-                    contentDescription = null
+        when (textFiledMode) {
+            SEARCH_TEXT_FIELD -> {
+                HousSearchTextField(
+                    text = text,
+                    hint = hint,
+                    innerTextField = innerTextField
                 )
             }
-            Box(
-                modifier = Modifier.fillMaxHeight(),
-                contentAlignment = if (isPrefixIcon) Alignment.CenterStart else Alignment.TopStart
-            ) {
-                if (text.isEmpty()) {
-                    Text(
-                        text = hint,
-                        color = HousG5,
-                        style = HousTheme.typography.b2
-                    )
-                }
-                innerTextField()
+            RIGHT_LIMITED_TEXT_FIELD -> {
+                HousRightLimitedTextField(
+                    text = text,
+                    limitTextCount = limitTextCount,
+                    innerTextField = innerTextField
+                )
+            }
+            BOTTOM_END_TEXT_FIELD -> {
+                HousBottomEndLimitedTextField(
+                    text = text,
+                    limitTextCount = limitTextCount,
+                    innerTextField = innerTextField
+                )
             }
         }
     }
 }
 
+@Composable
+private fun HousSearchTextField(
+    text: String,
+    hint: String,
+    innerTextField: @Composable () -> Unit
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Image(
+            painter = painterResource(id = R.drawable.ic_search),
+            contentDescription = null
+        )
+        Box(
+            modifier = Modifier.fillMaxHeight(),
+            contentAlignment = Alignment.CenterStart
+        ) {
+            if (text.isEmpty()) {
+                Text(
+                    text = hint,
+                    color = HousG5,
+                    style = HousTheme.typography.b2
+                )
+            }
+            innerTextField()
+        }
+    }
+}
+
+@Composable
+private fun HousRightLimitedTextField(
+    text: String,
+    limitTextCount: Int,
+    innerTextField: @Composable () -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        innerTextField()
+        Text(
+            text = "${text.length}/${limitTextCount}",
+            style = HousTheme.typography.en2,
+            color = HousG5
+        )
+    }
+}
+
+@Composable
+private fun HousBottomEndLimitedTextField(
+    text: String,
+    limitTextCount: Int,
+    innerTextField: @Composable () -> Unit
+) {
+    Column(
+        modifier = Modifier.height(136.dp),
+        verticalArrangement = Arrangement.SpaceBetween
+    ) {
+        innerTextField()
+        Text(
+            modifier = Modifier
+                .wrapContentSize()
+                .fillMaxWidth(),
+            text = "${text.length}/${limitTextCount}",
+            textAlign = TextAlign.End,
+            style = HousTheme.typography.en2,
+            color = HousG5
+        )
+    }
+}
+
 @Preview(name = "검색 text field")
 @Composable
-private fun DescriptionTextFieldPreview() {
+private fun TextFieldPreview() {
     HousTheme {
         var text by remember { mutableStateOf("") }
         val onChange: (String) -> Unit = { text = it }
-        HousSearchTextField(
+        HousTextField(
+            textFiledMode = SEARCH_TEXT_FIELD,
             text = text,
             onTextChange = onChange,
             hint = "검색하기",
@@ -215,35 +270,33 @@ private fun DescriptionTextFieldPreview() {
     }
 }
 
-@Preview(name = "왼쪽에 제한이 있는 text field")
+@Preview(name = "우측에 제한이 있는 text field")
 @Composable
 private fun HousLeftLimitedTextFieldPreview() {
     HousTheme {
         var text by remember { mutableStateOf("") }
         val onChange: (String) -> Unit = { text = it }
-        HousLeftLimitedTextField(
+        HousTextField(
+            textFiledMode = RIGHT_LIMITED_TEXT_FIELD,
             modifier = Modifier,
             text = text,
             onTextChange = onChange,
-            color = HousG1,
-            limitTextCount = 20
         )
     }
 }
 
-@Preview(name = "아래쪽에 제한이 있는 text field")
+@Preview(name = "우측 아래에 제한이 있는 text field")
 @Composable
-private fun HousBottomLimitedTextFieldPreview() {
+private fun HousBottomEndLimitedTextFieldPreview() {
     HousTheme {
         var text by remember { mutableStateOf("") }
         val onChange: (String) -> Unit = { text = it }
-        HousBottomLimitedTextField(
+        HousTextField(
+            textFiledMode = BOTTOM_END_TEXT_FIELD,
+            limitTextCount = 50,
             modifier = Modifier,
             text = text,
             onTextChange = onChange,
-            color = HousBlueL2,
-            height = 136.dp,
-            limitTextCount = 50
         )
     }
 }

--- a/designsystem/src/main/java/hous/release/designsystem/component/HousTextField.kt
+++ b/designsystem/src/main/java/hous/release/designsystem/component/HousTextField.kt
@@ -27,10 +27,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
@@ -47,49 +47,6 @@ import hous.release.designsystem.theme.HousTheme
 const val SEARCH_TEXT_FIELD = 0
 const val RIGHT_LIMITED_TEXT_FIELD = 1
 const val BOTTOM_END_TEXT_FIELD = 2
-
-@Composable
-fun HousLeftLimitedTextField(
-    modifier: Modifier = Modifier,
-    text: String,
-    color: Color,
-    limitTextCount: Int,
-    localFocusManager: FocusManager = LocalFocusManager.current,
-    onTextChange: (String) -> Unit
-) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(8.dp))
-            .background(color)
-            .padding(horizontal = 16.dp, vertical = 11.dp)
-    ) {
-        HousTextField(
-            textFiledMode = RIGHT_LIMITED_TEXT_FIELD,
-            modifier = Modifier
-                .height(IntrinsicSize.Min)
-                .weight(1f),
-            text = text,
-            onTextChange = { innerText ->
-                if (innerText.length <= limitTextCount) onTextChange(innerText)
-            },
-            keyboardOptions = KeyboardOptions.Default.copy(
-                capitalization = KeyboardCapitalization.Sentences,
-                autoCorrect = true,
-                keyboardType = KeyboardType.Text,
-                imeAction = ImeAction.Done
-            ),
-            keyboardActions = KeyboardActions(
-                onDone = { localFocusManager.clearFocus() }
-            ),
-        )
-        Text(
-            text = "${text.length}/$limitTextCount",
-            style = HousTheme.typography.en2,
-            color = HousG5
-        )
-    }
-}
 
 @Composable
 @Deprecated(
@@ -224,7 +181,11 @@ private fun HousRightLimitedTextField(
     ) {
         innerTextField()
         Text(
-            text = "${text.length}/${limitTextCount}",
+            text = String.format(
+                stringResource(id = R.string.text_field_limit_count),
+                text.length,
+                limitTextCount
+            ),
             style = HousTheme.typography.en2,
             color = HousG5
         )
@@ -246,7 +207,11 @@ private fun HousBottomEndLimitedTextField(
             modifier = Modifier
                 .wrapContentSize()
                 .fillMaxWidth(),
-            text = "${text.length}/${limitTextCount}",
+            text = String.format(
+                stringResource(id = R.string.text_field_limit_count),
+                text.length,
+                limitTextCount
+            ),
             textAlign = TextAlign.End,
             style = HousTheme.typography.en2,
             color = HousG5

--- a/designsystem/src/main/res/values/strings.xml
+++ b/designsystem/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="todo_detail_bs_edit">수정하기</string>
     <string name="todo_detail_bs_delete">삭제하기</string>
     <string name="todo_limit_dialog_check">알겠어요!</string>
+    <string name="text_field_limit_count">%d/%d</string>
 </resources>

--- a/feature/todo/src/main/java/hous/release/feature/todo/detail/TodoDetailScreen.kt
+++ b/feature/todo/src/main/java/hous/release/feature/todo/detail/TodoDetailScreen.kt
@@ -46,7 +46,8 @@ import androidx.lifecycle.lifecycleScope
 import hous.release.designsystem.component.FabScreenSlot
 import hous.release.designsystem.component.HousDialog
 import hous.release.designsystem.component.HousLimitDialog
-import hous.release.designsystem.component.HousSearchTextField
+import hous.release.designsystem.component.HousTextField
+import hous.release.designsystem.component.SEARCH_TEXT_FIELD
 import hous.release.designsystem.theme.HousG5
 import hous.release.designsystem.theme.HousTheme
 import hous.release.domain.entity.TodoDetail
@@ -222,7 +223,9 @@ private fun TodoDetailContent(
     ) {
         TodoDetailToolbar(finish = finish)
         Spacer(modifier = Modifier.height(4.dp))
-        HousSearchTextField(
+        HousTextField(
+            textFiledMode = SEARCH_TEXT_FIELD,
+            modifier = Modifier,
             text = searchText,
             hint = stringResource(R.string.todo_detail_textfield_hint),
             onTextChange = writeSearchText
@@ -299,13 +302,15 @@ private fun EmptyGuideText(
 ) {
     val focusManager = LocalFocusManager.current
     Box(
-        modifier = Modifier.fillMaxSize().pointerInput(Unit) {
-            detectTapGestures(
-                onPress = {
-                    focusManager.clearFocus()
-                }
-            )
-        },
+        modifier = Modifier
+            .fillMaxSize()
+            .pointerInput(Unit) {
+                detectTapGestures(
+                    onPress = {
+                        focusManager.clearFocus()
+                    }
+                )
+            },
         contentAlignment = Alignment.Center
     ) {
         Text(

--- a/feature/todo/src/main/java/hous/release/feature/todo/detail/TodoDetailScreen.kt
+++ b/feature/todo/src/main/java/hous/release/feature/todo/detail/TodoDetailScreen.kt
@@ -16,6 +16,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetValue
@@ -31,10 +33,15 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -204,19 +211,20 @@ private fun TodoDetailContent(
     selectedDayOfWeek: String,
     selectedHomies: String,
     todos: List<TodoWithNew>,
+    localFocusManager: FocusManager = LocalFocusManager.current,
     writeSearchText: (String) -> Unit,
     showFilterBottomSheet: () -> Unit,
     showToDoDetailBottomSheet: (Int) -> Unit,
     finish: () -> Unit
 ) {
-    val focusManager = LocalFocusManager.current
     Column(
         modifier = Modifier
+            .fillMaxSize()
             .padding(horizontal = 16.dp)
             .pointerInput(Unit) {
                 detectTapGestures(
                     onPress = {
-                        focusManager.clearFocus()
+                        localFocusManager.clearFocus()
                     }
                 )
             }
@@ -228,7 +236,16 @@ private fun TodoDetailContent(
             modifier = Modifier,
             text = searchText,
             hint = stringResource(R.string.todo_detail_textfield_hint),
-            onTextChange = writeSearchText
+            onTextChange = writeSearchText,
+            keyboardOptions = KeyboardOptions.Default.copy(
+                capitalization = KeyboardCapitalization.Sentences,
+                autoCorrect = true,
+                keyboardType = KeyboardType.Text,
+                imeAction = ImeAction.Done
+            ),
+            keyboardActions = KeyboardActions(
+                onDone = { localFocusManager.clearFocus() }
+            )
         )
         Spacer(modifier = Modifier.height(12.dp))
         TodoFilterAndSearchResult(
@@ -244,10 +261,12 @@ private fun TodoDetailContent(
                 todos = todos,
                 showToDoDetailBottomSheet = showToDoDetailBottomSheet
             )
+        } else {
+            EmptyGuideText(
+                modifier = Modifier.fillMaxSize(),
+                searchText = searchText
+            )
         }
-    }
-    if (todos.isEmpty()) {
-        EmptyGuideText(searchText)
     }
 }
 
@@ -259,9 +278,7 @@ private fun Todos(
     LazyColumn {
         items(
             items = todos,
-            key = { todo ->
-                todo.id
-            }
+            key = { todo -> todo.id }
         ) { todo ->
             ToDoItem(
                 todo = todo,
@@ -298,26 +315,20 @@ private fun TodoFilterAndSearchResult(
 
 @Composable
 private fun EmptyGuideText(
+    modifier: Modifier,
     searchText: String
 ) {
-    val focusManager = LocalFocusManager.current
     Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .pointerInput(Unit) {
-                detectTapGestures(
-                    onPress = {
-                        focusManager.clearFocus()
-                    }
-                )
-            },
+        modifier = modifier,
         contentAlignment = Alignment.Center
     ) {
         Text(
-            text = if (searchText.isBlank()) stringResource(R.string.todo_detail_empty)
-            else stringResource(R.string.todo_filter_empty),
+            text = if (searchText.isBlank()) stringResource(R.string.todo_detail_empty) else stringResource(
+                R.string.todo_filter_empty
+            ),
             style = HousTheme.typography.b2,
-            color = HousG5
+            color = HousG5,
+            textAlign = TextAlign.Center
         )
     }
 }


### PR DESCRIPTION
## 관련 이슈
- closed #279 

## 작업한 내용
- compose textfield 리팩토링

https://github.com/Hous-Release/hous-AOS/assets/82709044/c367f794-01d3-463e-9063-7f85a00e2a8a


## PR 포인트
- text field 영역을 선택하면 파랑으로 입력을 안할 시 회색으로 기능 수정했습니다.

- 기능을 수정하며 design system 모듈 내에 있는 text field 리팩토링 해서 이전 SearchHousTextField 는 deprecated 됐습니다,,.! 
프리뷰 보고 @murjune rules 쪽도 반영하면 됩니다

- 고기집에서 말했던 문제!!!
- recomposition 문제가 아닌... text를 fillmaxsize 를 했기 때문에 터치 영역이 화면을 가득 채워서 터치가 안먹었던 것입니다... 
EmptyGuide 영역 수정 후 문제 해결했습니다~~!

