### PR TITLE
#302 [Feat] MainRule Screen에 대표 룰 UI 적용

### DIFF
--- a/app/src/main/java/hous/release/android/presentation/our_rules/component/main/MainRuleList.kt
+++ b/app/src/main/java/hous/release/android/presentation/our_rules/component/main/MainRuleList.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import hous.release.android.R
 import hous.release.designsystem.component.HousDot
+import hous.release.designsystem.component.HousDotType
 import hous.release.designsystem.component.HousRuleSlot
 import hous.release.designsystem.theme.HousBlue
 import hous.release.designsystem.theme.HousG5
@@ -76,7 +77,7 @@ private fun MainRuleItem(
         text = mainRule.name,
         isShowTrailingIcon = mainRule.isNew,
         leadingIcon = {
-            HousDot(mainRule.isNew)
+            HousDot(HousDotType.from(isNew = mainRule.isNew, isRepresent = mainRule.isRepresent))
         },
         trailingIcon = {
             Text(

--- a/data/src/main/java/hous/release/data/entity/response/rule/MainRulesResponse.kt
+++ b/data/src/main/java/hous/release/data/entity/response/rule/MainRulesResponse.kt
@@ -9,12 +9,14 @@ data class MainRulesResponse(
 data class MainRuleResponse(
     val id: Int = -1,
     val name: String = "",
+    val isRepresent: Boolean = false,
     val createdAt: String = "",
     val isNew: Boolean = false
 ) {
     fun toMainRule() = MainRule(
         id = id,
         name = name,
+        isRepresent = isRepresent,
         createdAt = createdAt.substringBefore('T').replace('-', '.'),
         isNew = isNew
     )

--- a/data/src/test/java/hous/release/data/repository/RuleRepositoryImplTest.kt
+++ b/data/src/test/java/hous/release/data/repository/RuleRepositoryImplTest.kt
@@ -35,12 +35,14 @@ internal class RuleRepositoryImplTest {
             MainRule(
                 34,
                 "dd123xd",
+                true,
                 "2023.03.16",
                 true
             ),
             MainRule(
                 35,
                 "ㄷ슏슛ㄷ",
+                true,
                 "2023.05.05",
                 false
             )
@@ -52,12 +54,14 @@ internal class RuleRepositoryImplTest {
                 MainRuleResponse(
                     34,
                     "dd123xd",
+                    true,
                     "2023-03-16T17:19:42.158498",
                     true
                 ),
                 MainRuleResponse(
                     35,
                     "ㄷ슏슛ㄷ",
+                    true,
                     "2023-05-05T19:31:34.794815",
                     false
                 )

--- a/data/src/test/java/hous/release/data/service/RuleServiceTest.kt
+++ b/data/src/test/java/hous/release/data/service/RuleServiceTest.kt
@@ -48,12 +48,14 @@ internal class RuleServiceTest {
                     MainRuleResponse(
                         34,
                         "dd123xd",
+                        true,
                         "2023-03-16T17:19:42.158498",
                         true
                     ),
                     MainRuleResponse(
                         35,
                         "ㄷ슏슛ㄷ",
+                        false,
                         "2023-05-05T19:31:34.794815",
                         false
                     )

--- a/data/src/test/res/rule/success_main_rules.json
+++ b/data/src/test/res/rule/success_main_rules.json
@@ -7,12 +7,14 @@
       {
         "id": 34,
         "name": "dd123xd",
+        "isRepresent": true,
         "createdAt": "2023-03-16T17:19:42.158498",
         "isNew": true
       },
       {
         "id": 35,
         "name": "ㄷ슏슛ㄷ",
+        "isRepresent": false,
         "createdAt": "2023-05-05T19:31:34.794815",
         "isNew": false
       }

--- a/designsystem/src/main/java/hous/release/designsystem/component/HousDot.kt
+++ b/designsystem/src/main/java/hous/release/designsystem/component/HousDot.kt
@@ -10,20 +10,43 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import hous.release.designsystem.theme.HousBlue
 import hous.release.designsystem.theme.HousBlueL1
 import hous.release.designsystem.theme.HousG3
 import hous.release.designsystem.theme.HousTheme
 
+enum class HousDotType {
+    NEW,
+    NORMAL,
+    REPRESENTATIVE;
+
+    companion object {
+        fun from(isNew: Boolean = false, isRepresent: Boolean = false): HousDotType {
+            return when {
+                isNew -> NEW
+                isRepresent -> REPRESENTATIVE
+                else -> NORMAL
+            }
+        }
+    }
+}
+
 @Composable
 fun HousDot(
-    isNew: Boolean = false
+    housDotType: HousDotType = HousDotType.NORMAL
 ) {
     Box(
         modifier = Modifier
             .padding(8.dp)
             .size(8.dp)
             .clip(CircleShape)
-            .background(if (isNew) HousBlueL1 else HousG3)
+            .background(
+                color = when (housDotType) {
+                    HousDotType.NEW -> HousBlueL1
+                    HousDotType.NORMAL -> HousG3
+                    HousDotType.REPRESENTATIVE -> HousBlue
+                }
+            )
     )
 }
 
@@ -31,7 +54,7 @@ fun HousDot(
 @Composable
 private fun HousDashPreview() {
     HousTheme {
-        HousDot(isNew = true)
+        HousDot(HousDotType.from(isNew = true))
     }
 }
 
@@ -40,5 +63,13 @@ private fun HousDashPreview() {
 private fun HousDashPreview2() {
     HousTheme {
         HousDot()
+    }
+}
+
+@Preview(name = "representative - hous dash", showBackground = true)
+@Composable
+private fun HousDashPreview3() {
+    HousTheme {
+        HousDot(HousDotType.from(isRepresent = true))
     }
 }

--- a/designsystem/src/main/java/hous/release/designsystem/component/HousRule.kt
+++ b/designsystem/src/main/java/hous/release/designsystem/component/HousRule.kt
@@ -59,7 +59,7 @@ fun HousEditRulePreview() {
             text = "text",
             isShowTrailingIcon = false,
             leadingIcon = {
-                HousDot(true)
+                HousDot()
             },
             trailingIcon = {
                 Text(

--- a/domain/src/main/java/hous/release/domain/entity/rule/MainRule.kt
+++ b/domain/src/main/java/hous/release/domain/entity/rule/MainRule.kt
@@ -5,6 +5,7 @@ import hous.release.domain.entity.Rule
 data class MainRule(
     override val id: Int = NO_ID,
     override val name: String = NO_NAME,
+    val isRepresent: Boolean = false,
     val createdAt: String = "",
     val isNew: Boolean = false
 ) : Rule(id, name) {


### PR DESCRIPTION
## 관련 이슈
- closed #302

![image](https://github.com/Hous-Release/hous-AOS/assets/87055456/06729101-1bba-4eb8-a493-5cc229cbb834)  

## 작업한 내용
- domain : MainRule에 isRepresent 프로퍼티 추가
- data : MainRuleResponse에 isRepresent 추가
- data/test : MainRuleResponse 변경사항 적용
- designSystem : HousDotType 적용 및 대표 룰 Dot 추가
- app : HousDot 변경 사항 적용

## PR 포인트
- 대표 룰 Dot 색은 아직 디자인이 안나와서 임의로 `HousBlue'로 했티비~
