### PR TITLE
[2.0.0 QA] Home + Our Rule + 룸메이트 성향 카드

### DIFF
--- a/app/src/main/java/hous/release/android/presentation/our_rules/component/RuleEmptyContent.kt
+++ b/app/src/main/java/hous/release/android/presentation/our_rules/component/RuleEmptyContent.kt
@@ -16,14 +16,17 @@ import hous.release.designsystem.theme.HousTheme
 
 @Composable
 fun RuleEmptyContent(
-    modifier: Modifier = Modifier.fillMaxWidth().padding(top = 88.dp)
+    text: String = stringResource(id = R.string.hous_empty_our_rules),
+    modifier: Modifier = Modifier
+        .fillMaxWidth()
+        .padding(top = 88.dp)
 ) {
     Column(
         modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
-            text = stringResource(id = R.string.hous_empty_our_rules),
+            text = text,
             color = HousG5,
             style = HousTheme.typography.b2
         )

--- a/app/src/main/java/hous/release/android/presentation/our_rules/component/dialog/AddRuleLimitedDialog.kt
+++ b/app/src/main/java/hous/release/android/presentation/our_rules/component/dialog/AddRuleLimitedDialog.kt
@@ -2,6 +2,7 @@ package hous.release.android.presentation.our_rules.component.dialog
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.window.DialogProperties
 import hous.release.android.R
 import hous.release.designsystem.component.HousLimitDialog
 
@@ -12,6 +13,10 @@ fun AddRuleLimitedDialog(
     HousLimitDialog(
         title = stringResource(R.string.our_rule_limit_title),
         content = stringResource(R.string.our_rule_limit_content),
-        onDismissRequest = onDismissRequest
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(
+            dismissOnBackPress = false,
+            dismissOnClickOutside = false
+        )
     )
 }

--- a/app/src/main/java/hous/release/android/presentation/our_rules/component/main/DetailRuleBottomSheetContent.kt
+++ b/app/src/main/java/hous/release/android/presentation/our_rules/component/main/DetailRuleBottomSheetContent.kt
@@ -54,7 +54,7 @@ fun DetailRuleBottomSheetContent(
             Spacer(modifier = Modifier.height(7.dp))
             if (detailRule.description.isEmpty()) {
                 Text(
-                    text = detailRule.description,
+                    text = "설명 없음",
                     style = HousTheme.typography.b2,
                     color = HousG4
                 )

--- a/app/src/main/java/hous/release/android/presentation/our_rules/component/main/MainRuleContent.kt
+++ b/app/src/main/java/hous/release/android/presentation/our_rules/component/main/MainRuleContent.kt
@@ -25,7 +25,8 @@ import hous.release.feature.todo.R
 
 @Composable
 fun MainRuleContent(
-    mainRules: List<Rule> = emptyList(),
+    filteredRules: List<Rule> = emptyList(),
+    originRules: List<Rule> = emptyList(),
     searchQuery: String = "",
     onSearch: (String) -> Unit = {},
     onOpenDetailRule: (Int) -> Unit = {},
@@ -75,7 +76,8 @@ fun MainRuleContent(
                 )
             )
             MainRuleList(
-                mainRules = mainRules,
+                originRules = originRules,
+                filteredRules = filteredRules,
                 onNavigateToDetailRule = onOpenDetailRule
             )
         }
@@ -87,7 +89,7 @@ fun MainRuleContent(
 private fun MainRuleScreenPreView2() {
     HousTheme {
         MainRuleContent(
-            mainRules = listOf(
+            filteredRules = listOf(
                 Rule().copy(id = 1, name = "test1", isNew = true),
                 Rule().copy(id = 2, name = "test2", isNew = false),
                 Rule().copy(id = 3, name = "test3", isNew = true),

--- a/app/src/main/java/hous/release/android/presentation/our_rules/component/main/MainRuleList.kt
+++ b/app/src/main/java/hous/release/android/presentation/our_rules/component/main/MainRuleList.kt
@@ -12,8 +12,10 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import hous.release.android.R
 import hous.release.android.presentation.our_rules.component.RuleEmptyContent
 import hous.release.designsystem.component.HousDot
 import hous.release.designsystem.component.HousDotType
@@ -25,18 +27,25 @@ import hous.release.domain.entity.rule.Rule
 @Composable
 fun MainRuleList(
     onNavigateToDetailRule: (Int) -> Unit = {},
-    mainRules: List<Rule> = emptyList()
+    originRules: List<Rule> = emptyList(),
+    filteredRules: List<Rule> = emptyList()
 ) {
-    if (mainRules.isEmpty()) {
-        RuleEmptyContent()
-    } else {
-        Spacer(modifier = Modifier.height(16.dp))
-        LazyColumn {
-            itemsIndexed(mainRules, key = { _, rule -> rule.id }) { _, rule ->
-                MainRuleItem(
-                    onClick = { onNavigateToDetailRule(rule.id) },
-                    mainRule = rule
-                )
+    when {
+        originRules.isEmpty() -> {
+            RuleEmptyContent(text = stringResource(id = R.string.hous_empty_our_rules))
+        }
+        filteredRules.isEmpty() -> {
+            RuleEmptyContent(text = stringResource(id = R.string.hous_filterd_empty_our_rules))
+        }
+        else -> {
+            Spacer(modifier = Modifier.height(16.dp))
+            LazyColumn {
+                itemsIndexed(filteredRules, key = { _, rule -> rule.id }) { _, rule ->
+                    MainRuleItem(
+                        onClick = { onNavigateToDetailRule(rule.id) },
+                        mainRule = rule
+                    )
+                }
             }
         }
     }
@@ -72,7 +81,7 @@ private fun MainRuleItem(
     )
 }
 
-@Preview(name = "empty content", showBackground = true)
+@Preview(name = "empty origin rules content", showBackground = true)
 @Composable
 private fun EmptyContentPreview() {
     HousTheme {
@@ -82,12 +91,22 @@ private fun EmptyContentPreview() {
     }
 }
 
+@Preview(name = "empty filtered Rules", showBackground = true)
+@Composable
+private fun EmptyContentPreview2() {
+    HousTheme {
+        Surface {
+            MainRuleList(originRules = listOf(Rule().copy(id = 1, name = "test1")))
+        }
+    }
+}
+
 @Preview(name = "MainRuleContent", showBackground = true)
 @Composable
 private fun MainRuleContentPreview() {
     HousTheme {
         MainRuleList(
-            mainRules = listOf(
+            filteredRules = listOf(
                 Rule().copy(id = 1, name = "test1", isNew = true),
                 Rule().copy(id = 2, name = "test2", isNew = false),
                 Rule().copy(id = 3, name = "test3", isNew = true),

--- a/app/src/main/java/hous/release/android/presentation/our_rules/component/main/RuleGuideBottomSheetContent.kt
+++ b/app/src/main/java/hous/release/android/presentation/our_rules/component/main/RuleGuideBottomSheetContent.kt
@@ -61,10 +61,6 @@ fun RuleGuideBottomSheetContent() {
                     style = HousTheme.typography.b1
                 )
                 Spacer(Modifier.height(13.dp))
-                Text(
-                    text = "Page: $page",
-                    textAlign = TextAlign.Center
-                )
                 RuleGuideLottie(idx = page)
                 Spacer(Modifier.height(20.dp))
 

--- a/app/src/main/java/hous/release/android/presentation/our_rules/component/main/RuleGuideBottomSheetContent.kt
+++ b/app/src/main/java/hous/release/android/presentation/our_rules/component/main/RuleGuideBottomSheetContent.kt
@@ -35,6 +35,17 @@ import kotlinx.coroutines.launch
 
 // https://github.com/android/snippets/blob/5ae1f7852164d98d055b3cc6b463705989cff231/compose/snippets/src/main/java/com/example/compose/snippets/layouts/PagerSnippets.kt#L93-L103
 
+private val titleList = listOf(
+    "우리집 Rules란?",
+    "대표 Rules 선택하기",
+    "대표 Rules 선택 시 주의!"
+)
+
+private val descriptionList = listOf(
+    "Rules는 우리 호미들이 꼭 지켜야 하는 규칙이에요!",
+    "우리 집 대표 Rules를 선택하면 홈에서 바로 확인할 수 있어요!",
+    "대표 Rules는 딱 3개까지만 고정할 수 있어요!"
+)
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun RuleGuideBottomSheetContent() {
@@ -55,7 +66,7 @@ fun RuleGuideBottomSheetContent() {
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Text(
-                    text = "룰스 고정하기",
+                    text = titleList[page],
                     color = HousBlack,
                     textAlign = TextAlign.Center,
                     style = HousTheme.typography.b1
@@ -65,7 +76,7 @@ fun RuleGuideBottomSheetContent() {
                 Spacer(Modifier.height(20.dp))
 
                 Text(
-                    text = "룰스 고정 어쩌구 저쩌구",
+                    text = descriptionList[page],
                     color = HousG6,
                     textAlign = TextAlign.Center,
                     style = HousTheme.typography.description

--- a/app/src/main/java/hous/release/android/presentation/our_rules/component/update/BasicUpdateRuleScreen.kt
+++ b/app/src/main/java/hous/release/android/presentation/our_rules/component/update/BasicUpdateRuleScreen.kt
@@ -85,7 +85,7 @@ fun BasicUpdateRuleScreen(
                 textFielddMode = HousTextFieldMode.RIGHT_LIMITED,
                 text = ruleName,
                 onTextChange = changeName,
-                limitTextCount = 10,
+                limitTextCount = 20,
                 keyboardOptions = KeyboardOptions.Default.copy(
                     imeAction = ImeAction.Next
                 ),

--- a/app/src/main/java/hous/release/android/presentation/our_rules/graph/RuleNavGraph.kt
+++ b/app/src/main/java/hous/release/android/presentation/our_rules/graph/RuleNavGraph.kt
@@ -97,7 +97,8 @@ private fun NavGraphBuilder.mainRuleScreen(
 
         MainRuleScreen(
             detailRule = uiState.value.detailRule,
-            mainRules = uiState.value.filteredRules,
+            filteredRules = uiState.value.filteredRules,
+            originRules = uiState.value.originRules,
             searchQuery = uiState.value.searchQuery,
             fetchDetailRuleById = viewModel::fetchDetailRule,
             onSearch = viewModel::searchRule,

--- a/app/src/main/java/hous/release/android/presentation/our_rules/screen/MainRuleScreen.kt
+++ b/app/src/main/java/hous/release/android/presentation/our_rules/screen/MainRuleScreen.kt
@@ -32,7 +32,8 @@ import kotlinx.coroutines.launch
 @Composable
 fun MainRuleScreen(
     detailRule: DetailRuleUiModel = DetailRuleUiModel(),
-    mainRules: List<Rule> = emptyList(),
+    filteredRules: List<Rule> = emptyList(),
+    originRules: List<Rule> = emptyList(),
     searchQuery: String = "",
     fetchDetailRuleById: (Int) -> Unit = {},
     deleteRule: () -> Unit = {},
@@ -107,7 +108,8 @@ fun MainRuleScreen(
         sheetBackgroundColor = HousWhite
     ) {
         MainRuleContent(
-            mainRules = mainRules,
+            filteredRules = filteredRules,
+            originRules = originRules,
             searchQuery = searchQuery,
             onSearch = onSearch,
             onOpenDetailRule = { id ->
@@ -135,7 +137,7 @@ fun MainRuleScreen(
 private fun MainRuleScreenPreView2() {
     HousTheme {
         MainRuleScreen(
-            mainRules = listOf(
+            filteredRules = listOf(
                 Rule().copy(id = 1, name = "test1", isNew = true),
                 Rule().copy(id = 2, name = "test2", isNew = false),
                 Rule().copy(id = 3, name = "test3", isNew = true),

--- a/app/src/main/res/layout/activity_homie_profile.xml
+++ b/app/src/main/res/layout/activity_homie_profile.xml
@@ -206,9 +206,9 @@
                     android:layout_width="match_parent"
                     android:layout_height="1dp"
                     android:layout_marginHorizontal="16dp"
-                    android:layout_marginTop="28dp"
+                    android:layout_marginTop="20dp"
                     android:background="@color/hous_g_0"
-                    app:layout_constraintTop_toBottomOf="@id/tv_homie_profile_introduction" />
+                    app:layout_constraintTop_toBottomOf="@id/tv_homie_profile_representation" />
 
                 <FrameLayout
                     android:id="@+id/fl_homie_profile_personality"

--- a/app/src/main/res/layout/activity_homie_profile.xml
+++ b/app/src/main/res/layout/activity_homie_profile.xml
@@ -206,9 +206,9 @@
                     android:layout_width="match_parent"
                     android:layout_height="1dp"
                     android:layout_marginHorizontal="16dp"
-                    android:layout_marginTop="48dp"
+                    android:layout_marginTop="28dp"
                     android:background="@color/hous_g_0"
-                    app:layout_constraintTop_toBottomOf="@id/iv_homie_profile_representation_image_empty" />
+                    app:layout_constraintTop_toBottomOf="@id/tv_homie_profile_introduction" />
 
                 <FrameLayout
                     android:id="@+id/fl_homie_profile_personality"

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -255,7 +255,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="1dp"
                     android:layout_marginHorizontal="16dp"
-                    android:layout_marginTop="47dp"
+                    android:layout_marginTop="28dp"
                     android:background="@color/hous_g_0"
                     app:layout_constraintTop_toBottomOf="@id/tv_profile_introduction" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,6 +111,7 @@
     <string name="hous_our_rules">Our Rules</string>
     <string name="hous_our_rules_img_desc">btn_of_our_rules</string>
     <string name="hous_empty_our_rules">아직 우리 집 Rules가 없어요!</string>
+    <string name="hous_filterd_empty_our_rules">해당되는 Rules가 없어요!</string>
     <string name="hous_empty_our_rules_add">다른 Rule도 추가해보세요!</string>
     <string name="our_rule_duplicate_rule">똑같은 이름의 Rule이 있어요!</string>
     <string name="our_rule_limit_photo_count">사진은 5개 까지만 추가할 수 있어요!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,7 +117,7 @@
     <string name="our_rule_limit_photo_count">사진은 5개 까지만 추가할 수 있어요!</string>
     <string name="our_rule_limit_represent_rules_count">대표 rule 은 3개 까지만 추가할 수 있어요!</string>
     <string name="our_rule_limit_title">Rules 개수 초과</string>
-    <string name="our_rule_limit_content">우리 집 rule이 너무 많아요!\n필요하지 않은 rule을 삭제하고\n다시 시도해주세요~</string>
+    <string name="our_rule_limit_content">우리 집 Rules가 너무 많아요!\n필요하지 않은 rule을 삭제하고\n다시 시도해 주세요~</string>
     <string name="our_rule_empty_description">아직 우리 집 Rules가 없어요!</string>
     <string name="our_rule_add_new_rule_title">Rules 추가</string>
     <string name="our_rule_edit_rule_title">Rules 수정</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -188,7 +188,7 @@
     <string name="edit_hous_name_back_img_desc">back button</string>
     <string name="edit_hous_name_done">저장</string>
     <string name="edit_hous_name_title">우리 집 별명 바꾸기</string>
-    <string name="edit_hous_name_description">멤버들이 확인할 수 있도록 방 이름을 설정해주세요.</string>
+    <string name="edit_hous_name_description">다른 호미들이 확인할 수 있도록 방 이름을 설정해주세요.</string>
     <string name="edit_hous_name_count">%d/8</string>
 
     <!-- To-Do -->

--- a/feature/todo/src/main/res/values/strings.xml
+++ b/feature/todo/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
     <string name="todo_filter_homy">호미</string>
     <string name="filter_search_result">검색 결과</string>
     <string name="filter_search_result_postfix">개</string>
-    <string name="todo_detail_textfield_hint">검색하기</string>
+    <string name="todo_detail_textfield_hint">Rules 검색하기</string>
     <string name="todo_detail_empty">아직 우리집 to-do가 없어요!</string>
     <string name="todo_filter_empty">해당되는 to-do가 없어요!</string>
     <string name="todo_delete_title">안녕, to-do...</string>


### PR DESCRIPTION
## 관련 이슈
- #326

## ISSUE
- [피그마](https://www.figma.com/file/XXDlWUtyxsyAQSHZVe1ErE/Design_%EB%A6%B4%EB%A6%AC%EC%A6%88?node-id=4079%3A14568&mode=dev)
- [QA 시트](https://docs.google.com/spreadsheets/d/1CiTMTRq8CYhyaOQESJc8gEXmKAkC702JAWn9hkUEn90/edit#gid=1797783541)

# To-Do

## 우리 집 별명 수정
- [x] 라이팅 : 멤버들이 -> 다른 호미들이(요렇게 수정해 주세요! 호미들 호칭을 좀 더 익숙하게 볼 수 있도록~)

## Rules 가이드
- [x] : 룰스 고정하기~룰스 고정 어쩌구 저쩌구 사이에 있는 "Page : N"은 없어도 될 것 같아요!
- [x] : 가이드 라이팅(기획에 추가해 두었습니다! - 근데 라이팅 QA할 때 전체적으로 다시 전달 드릴 예정쓰.)


## Rules (main)
- [x] : 검색하기 -> Ruels 검색하기 
- [x] : 검색 없을 때 empty 뷰 -  현재 검색 시 일치하는 규칙 없을 때 "아직 우리 집 Rules가 없어요!" 노출.
(라이팅 상으로는 "해당되는 Rules가 없어요!"인데, 우선순위 낮은 수정 이슈입니다!)

## Rule Detail
- 이거 to-do bottom sheet에서도 마찬가지인데, to-do는 다 text data라 크게 티가 안 나는 듯!(to-do에서도 적어둘게요~)
- [x] : 피그마 디자인 상으로는 규칙 설명이 비어있는 경우, '설명 없음' 텍스트가 있는데 현재는 그 empty text가 보이지 않는 것 같습니다!

## Rules 추가 개수 제한 Dialog
- [x] : 라이팅 rule -> Rules로(2개) 바꾸면 좋을 것 같아요~
- [x] : 시도해주세요 -> 시도해 주세요(띄어쓰기!)
- [x] : 팝업 외 영역 클릭 시 닫힘.
- [x] : 뒤로 가기 시 닫힘

## Rules add
- [x] : 규칙 제목 글자수도 20자

## 룸메이트 성향 카드_A
- [x] : Max text로 자기 소개를 작성할 경우, 구분선 침범 이슈 있습니다!(슬랙 화면 공유.)
